### PR TITLE
Custom Weapon and Attachment System

### DIFF
--- a/vscripts/sh_survival_loot.gnut
+++ b/vscripts/sh_survival_loot.gnut
@@ -2848,7 +2848,7 @@ void function Inventory_RegisterNetworking()
 {
 	Remote_RegisterClientFunction( "ServerCallback_PickedupItem", "entity", "int", 0, 256, "int", 0, 256 )
 	Remote_RegisterClientFunction( "ServerCallback_DroppedItem", "entity", "int", 0, 256 )
-	Remote_RegisterClientFunction( "ServerCallback_AttachedMod", "int", 0, 256, "int", 0, 256 )
+	Remote_RegisterClientFunction( "ServerCallback_AttachedMod", "int", 0, 100, "int", 0, 256 )
 }
 #endif // CLIENT || SERVER
 

--- a/vscripts/sh_survival_loot.gnut
+++ b/vscripts/sh_survival_loot.gnut
@@ -234,6 +234,8 @@ global enum eHealthPickupType
 
 	ULTIMATE
 
+	COMBO_FULL_SMALL
+
 	_count
 
 	INVALID = -1
@@ -513,6 +515,18 @@ void function SURVIVAL_Loot_InitShared()
 		file.healthPickups[ eHealthPickupType.HEALTH_SMALL ] <- healthPickup
 	}
 
+	{
+		HealthPickup healthPickup
+		{
+			healthPickup.lootData = SURVIVAL_Loot_GetLootDataByRef( "health_pickup_combo_full" )
+			healthPickup.interactionTime = 3.0
+			healthPickup.healAmount = 50.0
+			healthPickup.shieldAmount = 50.0
+			healthPickup.healTime = 0.0
+		}
+		file.healthPickups[ eHealthPickupType.COMBO_FULL_SMALL ] <- healthPickup
+	}
+
 	healthKitUseOrder.append(eHealthPickupType.SHIELD_LARGE)
 	healthKitUseOrder.append(eHealthPickupType.SHIELD_SMALL)
 	healthKitUseOrder.append(eHealthPickupType.COMBO_FULL)
@@ -604,12 +618,12 @@ void function SURVIVAL_Loot_InitShared()
 
 			int col = GetDataTableColumnByName( attachmentMatrix, data.baseWeapon )
 
-			string colFeatureFlagRef = GetDataTableString( attachmentMatrix, featureFlagRowIdx, col )
+			/*string colFeatureFlagRef = GetDataTableString( attachmentMatrix, featureFlagRowIdx, col )
 			if ( colFeatureFlagRef != "" && !GetFeatureFlagByString( colFeatureFlagRef ) )
 			{
 				printf( "Skipping weapon attachment data for %s because feature flag %s is off.", data.baseWeapon, colFeatureFlagRef )
 				continue
-			}
+			}*/
 
 			if ( col != -1 )
 			{
@@ -620,9 +634,22 @@ void function SURVIVAL_Loot_InitShared()
 					aData.compatibleWeapons.append( data.baseWeapon )
 				}
 			}
+			else if (IsAttachmentCompatibleWithCustomWeapon(data, aData)) aData.compatibleWeapons.append( data.baseWeapon )
 		}
 
 		file.attachmentMatrix[ attachmentName ] <- aData
+	}
+
+	foreach(CustomHopupData a in GetCustomHopupArray()){
+		AttachmentData aData
+		aData.ref = a.className
+		aData.attachPoint = a.attachmentSlot
+
+		foreach ( data in allWeapons )
+		{
+			if (IsAttachmentCompatibleWithCustomWeapon(data, aData)) aData.compatibleWeapons.append( data.baseWeapon )
+		}
+		file.attachmentMatrix[aData.ref] <- aData
 	}
 
 	foreach ( aData in file.attachmentMatrix )
@@ -680,6 +707,16 @@ void function SURVIVAL_Loot_InitShared()
 			aData.tagData.weaponRefs = attachmentUniques
 		}
 	}
+}
+
+bool function IsAttachmentCompatibleWithCustomWeapon(LootData weapon, AttachmentData att)
+{
+	if (!weapon.supportedAttachments.contains( att.attachPoint )) return false
+
+	array<string> mods = GetWeaponMods_Global( weapon.baseWeapon )
+	if (mods.contains(att.ref)) printt("Attachment", att.ref, "has been found to be compatible with", weapon.ref)
+	else return false
+	return true
 }
 
 #if SERVER
@@ -969,12 +1006,8 @@ bool function SURVIVAL_Loot_RunConditionalCheck( string ref, entity player )
 
 string function GetAttachPointForAttachment( string attachmentName )
 {
-	var attachmentMatrix = GetDataTable( $"datatable/weapon_attachment_matrix.rpak" )
-	int attachmentRow = GetDataTableRowMatchingStringValue( attachmentMatrix, GetDataTableColumnByName( attachmentMatrix, "attachmentName" ), attachmentName )
-	Assert( attachmentRow >= 0, "Attachment not defined in datatable/weapon_attachment_matrix.rpak" )
-	int attachmentPointColumn = GetDataTableColumnByName( attachmentMatrix, "attachmentPoint" )
 
-	return GetDataTableString( attachmentMatrix, attachmentRow, attachmentPointColumn )
+	return file.attachmentMatrix[attachmentName].attachPoint
 }
 
 #if CLIENT || SERVER
@@ -2829,7 +2862,7 @@ void function Inventory_RegisterNetworking()
 {
 	Remote_RegisterClientFunction( "ServerCallback_PickedupItem", "entity", "int", 0, 256, "int", 0, 256 )
 	Remote_RegisterClientFunction( "ServerCallback_DroppedItem", "entity", "int", 0, 256 )
-	Remote_RegisterClientFunction( "ServerCallback_AttachedMod", "int", 0, 100, "int", 0, 256 )
+	Remote_RegisterClientFunction( "ServerCallback_AttachedMod", "int", 0, 256, "int", 0, 256 )
 }
 #endif // CLIENT || SERVER
 

--- a/vscripts/sh_survival_loot.gnut
+++ b/vscripts/sh_survival_loot.gnut
@@ -234,8 +234,6 @@ global enum eHealthPickupType
 
 	ULTIMATE
 
-	COMBO_FULL_SMALL
-
 	_count
 
 	INVALID = -1
@@ -513,18 +511,6 @@ void function SURVIVAL_Loot_InitShared()
 			healthPickup.animName1p = "ptpov_health_injector_short"
 		}
 		file.healthPickups[ eHealthPickupType.HEALTH_SMALL ] <- healthPickup
-	}
-
-	{
-		HealthPickup healthPickup
-		{
-			healthPickup.lootData = SURVIVAL_Loot_GetLootDataByRef( "health_pickup_combo_full" )
-			healthPickup.interactionTime = 3.0
-			healthPickup.healAmount = 50.0
-			healthPickup.shieldAmount = 50.0
-			healthPickup.healTime = 0.0
-		}
-		file.healthPickups[ eHealthPickupType.COMBO_FULL_SMALL ] <- healthPickup
 	}
 
 	healthKitUseOrder.append(eHealthPickupType.SHIELD_LARGE)

--- a/vscripts/sh_survival_loot_all.gnut
+++ b/vscripts/sh_survival_loot_all.gnut
@@ -11,6 +11,7 @@ global function SURVIVAL_Loot_GetLootTypeFromString
 global function SURVIVAL_Loot_GetByTier
 
 global function SURVIVAL_Loot_IsUniqueAmmoWeapon
+global function GetCustomHopupArray
 
 #if CLIENT
 global function GetRarityColor
@@ -34,6 +35,20 @@ global enum eLootTier
 	HEIRLOOM
 
 	_count
+}
+
+global struct CustomHopupData
+{
+	string className,
+	string displayName,
+	string desc,
+	int tier,
+	asset icon,
+	asset model = $"mdl/weapons_r5/loot/_master/w_loot_wep_mods_chip.rmdl",
+	string attachmentSlot = "hopup",
+	float lowWeight = 5.0,
+	float medWeight = 10.0,
+	float highWeight = 25.0
 }
 
 global struct LootData
@@ -141,6 +156,7 @@ struct
 	bool                      initialized
 	array<string>             disabledRefs
 	array<string>             uniqueAmmoWeaponRefs
+	array<CustomHopupData>	  customHopups = []
 
 	#if(true)
 		table<EHI, array< OverrideDeathBoxRUI_NetworkOptimizedStruct > > EHIToOverrideDeathBoxRUIProfilesTable
@@ -159,6 +175,10 @@ struct
 
 array<string> attachmentSortOrder = ["barrel", "mag", "sight", "grip", "hopup"]
 
+array<CustomHopupData> function GetCustomHopupArray()
+{
+	return file.customHopups
+} 
 
 string function GetLootTableString( string ref, var datatable, int rowIndex, string columnName )
 {
@@ -211,6 +231,7 @@ void function SURVIVAL_Loot_All_InitShared()
 	string disabledRefs = GetCurrentPlaylistVarString( "survival_disabled_loot", " " )
 	file.disabledRefs = split( disabledRefs, " " )
 
+	array<string> icons = []
 	int numRows = GetDatatableRowCount( dt )
 	for ( int i = 0; i < numRows; i++ )
 	{
@@ -263,6 +284,7 @@ void function SURVIVAL_Loot_All_InitShared()
 
 		string supportedAttachmentsString  = GetLootTableString( data.ref, dt, i, "supportedAttachments" )
 		array<string> supportedAttachments = split( supportedAttachmentsString, " " )
+		if (data.ref == "mp_weapon_esaw" || data.ref == "mp_weapon_energy_ar") supportedAttachments.append("mag")
 		supportedAttachments.sort(
 			int function( string attachmentA, string attachmentB ) : ()
 			{
@@ -278,6 +300,7 @@ void function SURVIVAL_Loot_All_InitShared()
 		)
 		data.supportedAttachments = supportedAttachments
 
+		printt(data.ref, "| model:", string(GetLootTableAsset( data.ref, dt, i, "pickupModel" )))
 		data.lootTags = split( GetLootTableString( data.ref, dt, i, "lootTags" ), " " )
 
 		data.lootType = SURVIVAL_Loot_GetLootTypeFromString( lootType )
@@ -397,7 +420,11 @@ void function SURVIVAL_Loot_All_InitShared()
 		#endif
 	}
 
+	foreach(string icon in icons)
+	{
 
+	}
+	RegisterCustomWeapons()
 
 	#if(UI)
 		RegisterSignal( "GatherFriendInfo" )
@@ -406,8 +433,244 @@ void function SURVIVAL_Loot_All_InitShared()
 	#endif
 
 	file.initialized = true
-    
-}  
+}
+
+struct CustomWeaponData
+{
+	string className,
+	int tier,
+	array<string> baseMods,
+	array<string> supportedAttachments,
+	string pickupSound1p,
+	string pickupSound3p,
+	string weaponType,
+	float lowWeaponChance,
+	float medWeaponChance,
+	float highWeaponChance
+}
+
+void function RegisterCustomWeapons()
+{
+	{
+		CustomWeaponData data
+		data.className = "mp_weapon_epg"
+		data.tier = 5
+		data.baseMods = []
+		data.supportedAttachments = ["mag", "grip", "sight", "hopup"]
+		data.pickupSound1p = "survival_loot_pickup_weapon_dmr"
+		data.pickupSound3p = "survival_loot_pickup_3p_weapon_dmr"
+		data.weaponType = "assault"
+		data.lowWeaponChance = 5.0
+		data.medWeaponChance = 5.0
+		data.highWeaponChance = 5.0
+		// weaponTypes: assault, smg, lmg, sniper, shotgun, pistol
+		RegisterWeapon(data)
+	}
+	{
+		CustomWeaponData data
+		// Class name - the file name of the weapon, excluding extension
+		data.className = "mp_weapon_infinity_rifle"
+		// Tier - the displayed rarity of the weapon
+		data.tier = 5
+		// equip these mods on pickup.
+		data.baseMods = []
+		// what attachments does the weapon support
+		data.supportedAttachments = ["mag", "grip", "sight", "hopup", "barrel"]
+		// pickup sounds
+		data.pickupSound1p = "survival_loot_pickup_weapon_rspn101"
+		data.pickupSound3p = "survival_loot_pickup_3p_weapon_rspn101"
+		// weapon type - used for attachments.
+		// weaponTypes: assault, smg, lmg, sniper, shotgun, pistol
+		data.weaponType = "assault"
+		// weights for weapon to appear on ground.
+		// the game sets the chances to a sum of 100.
+		// the actual chance is dependent on all other custom weapons.
+		data.lowWeaponChance = 5.0
+		data.medWeaponChance = 5.0
+		data.highWeaponChance = 5.0
+		RegisterWeapon(data)
+	}
+	{
+		CustomHopupData data
+		// class name - the name of the mod to be added to a weapon once this hopup is equipped.
+		data.className = "hopup_cool"
+		// display name - the name displayed on pop-ups of this hop-up.
+		data.displayName = "Cool Hopup"
+		// description.
+		data.desc = "It's cool :)"
+		// Tier - the displayed rarity of the hop-up
+		data.tier = 2
+		// icon - the icon of the hop-up. defaults to the Choke Hop-up Icon.
+		data.icon = $"rui/pilot_loadout/mods/hopup_em_choke"
+		// model - the appearance of the hop-up on the ground.
+		data.model = $"mdl/weapons_r5/loot/_master/w_loot_wep_mods_chip.rmdl"
+		// The weight of the hop-up in Basic Tier Loot areas
+		data.lowWeight = 5.0
+		// The weight of the hop-up in Mid Tier Loot areas
+		data.medWeight = 15.0
+		// The weight of the hop-up in High Tier Loot areas
+		data.highWeight = 25.0
+		// create the hopup...
+		CreateCustomHopup(data)
+	}
+	{
+		CustomHopupData data
+		data.className = "hopup_barrel"
+		data.displayName = "Infinity Barrel"
+		data.desc = "1 part of many."
+		data.tier = 5
+		data.lowWeight = 5.0
+		data.medWeight = 15.0
+		data.highWeight = 25.0
+		data.attachmentSlot = "barrel"
+		data.icon = $"rui/pilot_loadout/mods/barrel_stabilizer"
+		data.model = $"mdl/weapons_r5/loot/_master/w_loot_wep_mods_suppr_v2b.rmdl"
+		CreateCustomHopup(data)
+	}
+	{
+		CustomHopupData data
+		data.className = "hopup_stock"
+		data.displayName = "Infinity Stock"
+		data.desc = "1 part of many."
+		data.tier = 5
+		data.lowWeight = 5.0
+		data.medWeight = 15.0
+		data.highWeight = 25.0
+		data.attachmentSlot = "grip"
+		data.icon = $"rui/pilot_loadout/mods/tactical_stock"
+		data.model = $"mdl/weapons_r5/loot/w_loot_wep_iso_stock_folded_regular.rmdl"
+		CreateCustomHopup(data)
+	}
+	{
+		CustomHopupData data
+		data.className = "hopup_mag"
+		data.displayName = "Infinity Mag"
+		data.desc = "1 part of many."
+		data.attachmentSlot = "mag"
+		data.tier = 5
+		data.lowWeight = 5.0
+		data.medWeight = 15.0
+		data.highWeight = 25.0
+		data.icon = $"rui/pilot_loadout/mods/light_mag"
+		data.model = $"mdl/weapons_r5/loot/_master/w_loot_wep_mods_mag_v1b.rmdl"
+		CreateCustomHopup(data)
+	}
+	{
+		CustomHopupData data
+		data.className = "hopup_sight"
+		data.displayName = "Infinity Sight"
+		data.desc = "1 part of many."
+		data.attachmentSlot = "sight"
+		data.tier = 5
+		data.lowWeight = 5.0
+		data.medWeight = 15.0
+		data.highWeight = 25.0
+		data.icon = $"rui/weapon_icons/attachments/hcog"
+		data.model = $"mdl/weapons_r5/loot/_master/w_loot_wep_mods_optic_cq_hcog_r1.rmdl"
+		CreateCustomHopup(data)
+	}
+	{
+		CustomHopupData data
+		data.className = "hopup_infinity"
+		data.displayName = "Infinity Hopup"
+		data.desc = "1 part of many."
+		data.attachmentSlot = "hopup"
+		data.tier = 5
+		data.lowWeight = 5.0
+		data.medWeight = 15.0
+		data.highWeight = 25.0
+		data.icon = $"rui/pilot_loadout/mods/hopup_em_choke"
+		CreateCustomHopup(data)
+	}
+}
+
+void function RegisterWeapon( CustomWeaponData weaponData )
+{
+	LootData data
+	
+	data.ref = weaponData.className
+	data.baseWeapon = weaponData.className
+	//RegisterWeaponForUse( data.baseWeapon )\
+	#if !UI
+	PrecacheWeapon(weaponData.className)
+	#endif
+	data.tier = weaponData.tier
+	data.pickupString = GetWeaponInfoFileKeyField_GlobalString( data.baseWeapon, "printName" )
+	data.desc = GetWeaponInfoFileKeyField_GlobalString( data.baseWeapon, "description" )
+	data.hudIcon = GetWeaponInfoFileKeyFieldAsset_Global( data.baseWeapon, "hud_icon" )
+	data.model = GetWeaponInfoFileKeyFieldAsset_Global( data.baseWeapon, "playermodel" )
+	data.pickupSound_3p = weaponData.pickupSound3p
+	data.pickupSound_1p = weaponData.pickupSound1p
+	data.attachmentStyle = "hopup"
+	if ( GetWeaponInfoFileKeyField_Global( data.baseWeapon, "ammo_pool_type" ) != null )
+		data.ammoType = GetWeaponInfoFileKeyField_GlobalString( data.baseWeapon, "ammo_pool_type" )
+
+	data.lootTags = [ weaponData.weaponType ]
+	data.lootType = eLootType.MAINWEAPON
+	
+	weaponData.supportedAttachments.sort(
+		int function( string attachmentA, string attachmentB ) : ()
+		{
+			int aIndex = attachmentSortOrder.find( attachmentA )
+			int bIndex = attachmentSortOrder.find( attachmentB )
+			if ( aIndex > bIndex )
+				return 1
+			else if ( aIndex < bIndex )
+				return -1
+			return 0
+		}
+	)
+	
+	data.supportedAttachments = weaponData.supportedAttachments
+	data.baseMods = weaponData.baseMods
+
+	data.index = file.lootIndexToString.len()
+	file.lootIndexToString.append( data.ref )
+	file.lootData[ data.ref ] <- data
+
+	#if SERVER
+		SURVIVAL_AddSpawnPointGroup( data.ref )
+	#endif
+	
+	#if !UI
+	if ( data.model != $"" )
+		PrecacheModel( data.model )
+	AddCustomItemToLootPool(data.ref, "weapon_low", weaponData.lowWeaponChance)
+	AddCustomItemToLootPool(data.ref, "weapon_medium", weaponData.medWeaponChance)
+	AddCustomItemToLootPool(data.ref, "weapon_high", weaponData.highWeaponChance)
+	#endif
+	#if CLIENT
+	RunUIScript( "SetupDevCommand", "Spawn " + data.pickupString, "script SpawnGenericLoot( \"" + data.ref + "\", gp()[0].GetOrigin(), <-1,-1,-1>, 1 )" )
+	#endif
+}
+
+void function CreateCustomHopup(CustomHopupData hopupData)
+{
+	LootData data
+
+	data.ref = hopupData.className
+	data.pickupString = hopupData.displayName
+	data.desc = hopupData.desc
+	data.hudIcon = hopupData.icon
+	data.model = hopupData.model
+	data.pickupSound_1p = "survival_loot_pickup_attachments"
+	data.pickupSound_3p = "survival_loot_pickup_3p_attachments"
+	data.tier = hopupData.tier
+	data.countPerDrop = 1
+	data.inventorySlotCount = 1
+	data.attachmentStyle = "hopup"
+	data.index = file.lootIndexToString.len()
+	data.lootTags = []
+	data.lootType = eLootType.ATTACHMENT
+	file.lootIndexToString.append( data.ref )
+	file.lootData[ data.ref ] <- data
+	#if !UI
+		AddCustomItemToLootPool(data.ref, "attachment_low", hopupData.lowWeight)
+		AddCustomItemToLootPool(data.ref, "attachment_medium", hopupData.medWeight)
+		AddCustomItemToLootPool(data.ref, "attachment_high", hopupData.highWeight)
+	#endif
+	file.customHopups.append(hopupData)
+}
 
 table< string, LootData > function SURVIVAL_Loot_GetLootDataTable()
 {

--- a/vscripts/sh_survival_loot_distribution.gnut
+++ b/vscripts/sh_survival_loot_distribution.gnut
@@ -1,6 +1,7 @@
 global function SURVIVAL_LootDistribution_InitShared
 global function SURVIVAL_GetWeightedItemFromGroup
 global function SURVIVAL_GetMultipleWeightedItemsFromGroup
+global function AddCustomItemToLootPool
 
 struct LootDistro
 {
@@ -31,7 +32,9 @@ void function SURVIVAL_LootDistribution_InitShared()
         }
         if(groupRef != "") //Found a group header, accumulate anything so far into the previous group 
         {
-            LootDistribution[ currentGroupRef ] <- clone distributions
+             if (currentGroupRef in LootDistribution)
+                LootDistribution[currentGroupRef].extend(clone distributions)
+            else LootDistribution[ currentGroupRef ] <- clone distributions
             distributions.clear()
             currentGroupRef = groupRef
         }
@@ -114,4 +117,11 @@ array<LootDistro> function UnpackGroup(string groupRef)
             unpackedDistro.append(distro)
     }   
     return unpackedDistro
+}
+
+void function AddCustomItemToLootPool(string itemRef, string groupRef, float chance)
+{
+    LootDistro ld = NewLootDistro(itemRef, chance)
+    if (groupRef in LootDistribution) LootDistribution[groupRef].append(ld)
+    else LootDistribution[groupRef] <- [ld]
 }

--- a/weapons/mp_weapon_epg.txt
+++ b/weapons/mp_weapon_epg.txt
@@ -1,3 +1,8 @@
+#base "_base_assault_rifle_optics.txt"
+#base "_base_mags_energy.txt"
+#base "_base_stocks_tactical.txt"
+#base "_base_shotgun_bolts.txt"
+
 WeaponData
 {
 	// General
@@ -6,11 +11,11 @@ WeaponData
 	"description" 									"EPG"
 	"longdesc"										"EPG"
 
-	"menu_icon"										"r2_ui/menus/loadout_icons/primary_weapon/primary_epg1"
-	"hud_icon"										"r2_ui/menus/loadout_icons/primary_weapon/primary_epg1"
+	"menu_icon"										"rui/weapon_icons/r5/weapon_charge_rifle"
+	"hud_icon"										"rui/weapon_icons/r5/weapon_charge_rifle"
 
 	"weaponClass" 									"human"
-	"fire_mode"   									"semi_auto"
+	"fire_mode"   									"automatic"
 	"body_type"										"heavy"
 	"aimassist_adspull_weaponclass"					"none"
 	"leveled_pickup"								"1"
@@ -27,61 +32,56 @@ WeaponData
 	"projectile_gravity_scale"						"0.0001"
 
 	"damage_flags"									"DF_BULLET | DF_GIB"
-	
+
 	"OnClientAnimEvent"								"GlobalClientEventHandler"
-//	"OnWeaponPrimaryAttack"							"OnWeaponPrimaryAttack_GenericMissile_Player"
-//	"OnWeaponNpcPrimaryAttack"						"OnWeaponPrimaryAttack_GenericMissile_NPC"
-	"OnWeaponPrimaryAttack"							"OnWeaponPrimaryAttack_GenericBoltWithDrop_Player"
-	"OnWeaponNpcPrimaryAttack"						"OnWeaponPrimaryAttack_GenericBoltWithDrop_NPC"
-	"OnWeaponActivate"								"OnWeaponActivate_updateViewmodelAmmo"
+	"OnWeaponPrimaryAttack"							"OnWeaponPrimaryAttack_GenericMissile_Player"
+	"OnWeaponNpcPrimaryAttack"						"OnWeaponPrimaryAttack_GenericMissile_NPC"
 
 	// Menu
 	"menu_category"                                 "special"
 	"menu_anim_class"                               "medium"
-	"stat_damage" 									"48"
+	"stat_damage" 									"80"
 	"stat_range"  									"60"
 	"stat_accuracy"   								"60"
 	"stat_rof"										"17"
 
 	// Models
-	"viewmodel"   									"mdl/weapons/epg/ptpov_epg.rmdl"
-	"playermodel" 									"mdl/weapons/epg/w_epg.rmdl"
-	"projectilemodel" 								"mdl/weapons/bullets/projectile_rocket_launcher_sram.rmdl"
-		// Effects
-	"impact_effect_table" 							"exp_plasma_LG"
-	"projectile_trail_effect_0" 					"wpn_grenade_frag_blue"
-	"projectile_trail_effect_1" 					"P_plasma_proj_MD_DLight"
-	"projectile_trail_attachment" 					"exhaust"
-	"vortex_absorb_effect"							"wpn_vortex_projectile_SuperSpec_FP"
-	"vortex_absorb_effect_third_person"				"wpn_vortex_projectile_SuperSpec"
-	"vortex_absorb_sound"							"Vortex_Shield_AbsorbRocket"
-	"vortex_absorb_sound_1p_vs_3p"					"Vortex_Shield_AbsorbRocket_1P_VS_3P"
-	"vortex_drain"									"0.0"
-	"projectile_adjust_to_gun_barrel"				"1"
+	"viewmodel"   									"mdl/weapons/defender/ptpov_defender.rmdl"
+	"playermodel" 									"mdl/weapons/defender/w_defender.rmdl"
+	"holster_type"									"anti_titan"
+	"projectilemodel"								"mdl/weapons/grenades/m20_f_grenade_projectile.rmdl"
+
+	// Effects
+	"projectile_trail_effect_0"						"P_grenade_thermite_trail"
+	"projectile_trail_attachment" 					"FX_TRAIL"
+	"vortex_absorb_effect"							"wpn_vortex_projectile_frag_FP"
+	"vortex_absorb_effect_third_person"				"wpn_vortex_projectile_frag"
+	"vortex_absorb_sound"							"Vortex_Shield_AbsorbBulletLarge"
+	"vortex_absorb_sound_1p_vs_3p"					"Vortex_Shield_AbsorbBulletLarge_1P_VS_3P"
+	"projectile_adjust_to_gun_barrel"				"0"
+	"projectile_adjust_to_hand"						"1"
+	"impact_effect_table"							"exp_frag_grenade"
 
 	"explosion_shake_radius"						"300"
 	"explosion_shake_amplitude"						"10"
 	"explosion_shake_frequency"						"35"
 	"explosion_shake_duration"						"0.5"
 
-	"fx_muzzle_flash_view"							"P_wpn_muzzleflash_epg_FP"
-	"fx_muzzle_flash_world"							"P_wpn_muzzleflash_epg"
-	"fx_muzzle_flash_attach"						"muzzle_flash"
+	//"fx_muzzle_flash_view"						"P_wpn_muzzleflash_epg_FP"
+	//"fx_muzzle_flash_world"						"P_wpn_muzzleflash_epg"
+	//"fx_muzzle_flash_attach"						"muzzle_flash"
 
 	// Sound
 	"projectile_flight_sound"						"weapon_epg_projectile_loop"
-	"sound_dryfire"									"spring_dryfire"
-	"sound_zoom_in"									"Weapon_Sidewinder_ADS_In"
-	"sound_zoom_out"								"Weapon_Sidewinder_ADS_Out"
-	"fire_sound_1_player_1p"						"Weapon_epg_Fire_1P"
-	"fire_sound_1_player_3p"						"Weapon_epg_Fire_3P"
-	"fire_sound_1_npc"								"Weapon_epg_Fire_NPC"
+	"sound_dryfire"									"weapon_thermitegrenade_idleburn_1p"
+	"sound_zoom_in"									"Weapon_Rangemaster_Kraber_ADS_In"
+	"sound_zoom_out"								"Weapon_Rangemaster_Kraber_ADS_Out"
+	"fire_sound_1_player_1p"						"Weapon_ChargeRifle_Fire_1P"
+	"fire_sound_1_player_3p"						"Weapon_ChargeRifle_Fire_3P"
+	"fire_sound_1_npc"								"Weapon_ChargeRifle_Fire_NPC"
 	"looping_sounds"								"0"
 
-	"idle_sound_player_1p"							"weapon_epg_idle_gears_1p"
-
-	"low_ammo_sound_name_1"							"EPG_LowAmmo_Shot1"
-	"low_ammo_sound_name_2"							"EPG_LowAmmo_Shot2"
+	"idle_sound_player_1p"							"GasGrenade_IdleHiss"
 
 
 	// Ammo
@@ -105,7 +105,7 @@ WeaponData
 		"ammo_no_remove_from_clip"                      "0"
         "ammo_no_remove_from_stockpile"                 "1"
 
-		"damage_near_value"   							"60"
+		"damage_near_value"   							"200"
 		"damage_far_value"								"60"
 		"damage_near_value_titanarmor"					"700"
 		"damage_far_value_titanarmor" 					"700"
@@ -113,7 +113,7 @@ WeaponData
 		"damage_near_distance"							"60"
 		"damage_far_distance" 							"60"
 
-		"explosion_damage"								"40"
+		"explosion_damage"								"120"
 		"explosion_damage_heavy_armor"					"700"
 
 		"red_crosshair_range" 							"2000"
@@ -276,23 +276,23 @@ WeaponData
 	"viewmodel_shake_right"							"0.0"
 
 
-	// Bob
+	// Bob - Hipfire
 	"bob_cycle_time"  								"0.4"
 	"bob_vert_dist"   								"0.19"
 	"bob_horz_dist"   								"0.1"
-	"bob_max_speed"   								"150"
+	"bob_max_speed"   								"173"
 	"bob_pitch"   									"0.75"
 	"bob_yaw" 										"-1.7"
 	"bob_roll"										"1.2"
 
-	// Bob zoomed
-	"bob_cycle_time_zoomed"								"0.4"
-	"bob_vert_dist_zoomed" 								"0.19"
-	"bob_horz_dist_zoomed" 								"0.1"
-	"bob_max_speed_zoomed" 								"150"
-	"bob_pitch_zoomed" 									"0.75"
-	"bob_yaw_zoomed" 									"-1.7"
-	"bob_roll_zoomed"									"1.2"
+	// Bob - ADS
+	"bob_cycle_time_zoomed"  						"0.7"
+	"bob_vert_dist_zoomed"   						"0.045"
+	"bob_horz_dist_zoomed"   						"0.07"
+	"bob_max_speed_zoomed"   						"155"
+//	"bob_pitch_zoomed"   							"0.0"
+	"bob_yaw_zoomed" 								"-0.01"
+	"bob_roll_zoomed"								"0.25"
 
 	// Rumble
 	"fire_rumble"									"rumble_grenadier"
@@ -343,49 +343,28 @@ WeaponData
 	"sway_turn_down_rotate_roll" 					"0.8"
 
 	// Zoomed Sway
-	"sway_rotate_attach_zoomed"  							"SWAY_ROTATE"
-	"sway_min_x_zoomed"  									"-0.5"
-	"sway_min_y_zoomed"  									"-0.5"
-	"sway_min_z_zoomed"  									"-0.6"
-	"sway_max_x_zoomed"  									"0.5"
-	"sway_max_y_zoomed"  									"0.5"
-	"sway_max_z_zoomed"  									"0.6"
-	"sway_min_pitch_zoomed"  								"-3"
-	"sway_min_yaw_zoomed"									"-2.5"
-	"sway_min_roll_zoomed"   								"-4"
-	"sway_max_pitch_zoomed"  								"3"
-	"sway_max_yaw_zoomed"									"2.5"
-	"sway_max_roll_zoomed"   								"4"
-	"sway_translate_gain_zoomed" 							"2.5"
-	"sway_rotate_gain_zoomed"								"7"
-	"sway_move_forward_translate_x_zoomed"   				"-0.1"
-	"sway_move_forward_translate_z_zoomed"   				"-0.5"
-	"sway_move_back_translate_x_zoomed"  					"0.2"
-	"sway_move_back_translate_z_zoomed"  					"-0.2"
-	"sway_move_left_translate_y_zoomed"  					"-1"
-	"sway_move_left_translate_z_zoomed"  					"-0.5"
-	"sway_move_left_rotate_roll_zoomed"  					"-4"
-	"sway_move_right_translate_y_zoomed" 					"1"
-	"sway_move_right_translate_z_zoomed" 					"-0.5"
-	"sway_move_right_rotate_roll_zoomed" 					"4"
-	"sway_move_up_translate_z_zoomed"						"-1"
-	"sway_move_down_translate_z_zoomed"  					"1"
-	"sway_turn_left_rotate_yaw_zoomed"   					"-2.5"
-	"sway_turn_right_rotate_yaw_zoomed"  					"2.5"
+	"sway_rotate_attach_zoomed"						"SWAY_ROTATE_ZOOMED"
+	"sway_rotate_attach_blend_time_zoomed"			"0.2"
+	"sway_rotate_gain_zoomed"						"5"
 
-	"sway_turn_left_translate_y_zoomed"  					".5"
-	"sway_turn_right_translate_y_zoomed"  					"-.5"
-	"sway_turn_up_translate_z_zoomed"  					".2"
-	"sway_turn_down_translate_z_zoomed"  					"-.2"
-	"sway_turn_up_translate_x_zoomed"  					".1"
-	"sway_turn_down_translate_x_zoomed"  					"-.1"
+	"sway_min_yaw_zoomed"							"-0.04"
+	"sway_max_yaw_zoomed"							"0.04"
+	"sway_turn_left_rotate_yaw_zoomed"				"-0.085"
+	"sway_turn_right_rotate_yaw_zoomed"				"0.085"
 
-	"sway_turn_left_rotate_roll_zoomed"   					"4"
-	"sway_turn_right_rotate_roll_zoomed"  					"-4"
-	"sway_turn_up_rotate_pitch_zoomed"   					"3"
-	"sway_turn_down_rotate_pitch_zoomed" 					"-3"
-	"sway_turn_up_rotate_roll_zoomed"   					"-0.8"
-	"sway_turn_down_rotate_roll_zoomed" 					"0.8"
+	"sway_min_roll_zoomed"   						"-1"
+	"sway_max_roll_zoomed"   						"1"
+	"sway_turn_left_rotate_roll_zoomed"   			"-1"
+	"sway_turn_right_rotate_roll_zoomed"  			"1"
+
+	"sway_move_right_rotate_roll_zoomed" 			"0.2"
+	"sway_move_left_rotate_roll_zoomed"  			"-0.2"
+
+	"sway_min_pitch_zoomed"  						"-0.02"
+	"sway_max_pitch_zoomed"  						"0.03"
+	"sway_turn_up_rotate_pitch_zoomed"				"0.07"
+	"sway_turn_down_rotate_pitch_zoomed"			"-0.07"
+
 
 	// WeaponED Unhandled Key/Values and custom script Key/Values
 	"deployfirst_time"								"1.25"
@@ -411,6 +390,7 @@ WeaponData
     "clip_bodygroup_show_for_milestone_1"	"0"
 
 	"bodygroup_ammo_index_count"			"7"
+	"ammo_pool_type"						"special"
 
 	Mods
 	{
@@ -425,6 +405,11 @@ WeaponData
         	"bodygroup1_set"	"0"
         	"bodygroup6_set"	"1"
         }
+		survival_finite_ammo
+		{
+			"uses_ammo_pool"						"1"
+			"ammo_no_remove_from_stockpile"			"0"
+		}
        	extended_ammo
 		{
 			"ammo_stockpile_max"				"120"
@@ -508,6 +493,11 @@ WeaponData
 			"damage_near_value"   							"35"
 			"damage_far_value"								"35"
 			"explosion_damage"								"35"
+		}
+
+		hopup_cool
+		{
+			"ammo_clip_size"						"*2"
 		}
 	}
 

--- a/weapons/mp_weapon_infinity_rifle.txt
+++ b/weapons/mp_weapon_infinity_rifle.txt
@@ -1,0 +1,543 @@
+#base "_base_assault_rifle.txt"
+#base "_base_mags_light.txt"
+#base "_base_barrels_medium.txt"
+
+WeaponData
+{
+	// General
+	"printname"   									"Infinity Rifle 301"
+	"shortprintname"								"IR301"
+	"description" 									"Once a gauntlet. Now it's stupid."
+	"longdesc"										"Once a gauntlet. Now it's stupid. dudeit'stheinfinitygauntlet"
+
+	"weapon_type_flags"								"WPT_PRIMARY"
+	"ammo_pool_type"								"bullet"
+
+    // UI/HUD
+	"menu_icon"										"rui/weapon_icons/r5/weapon_r301"
+	"hud_icon"										"rui/weapon_icons/r5/weapon_r301"
+
+	"weaponClass" 									"human"
+	"weaponSubClass"								"rifle"
+	"body_type"										"medium"
+	"fire_mode"   									"automatic"
+	"pickup_hold_prompt"  							"Hold [USE] [WEAPONNAME]"
+	"pickup_press_prompt" 							"[USE] [WEAPONNAME]"
+	"minimap_reveal_distance"						"32000"
+	"leveled_pickup"								"1"
+
+    "projectile_launch_speed"						"29000"
+
+	// Menu
+	"menu_category"                                 "ar"
+	"menu_anim_class"                               "medium"
+	"stat_damage" 									"55"
+	"stat_range"  									"65"
+	"stat_accuracy"   								"90"
+	"stat_rof"										"80"
+
+	// Models
+	"viewmodel"   									"mdl/weapons/rspn101/ptpov_rspn101.rmdl"
+	"playermodel" 									"mdl/weapons/rspn101/w_rspn101.rmdl"
+	"holster_type"									"rifle"
+
+	"chroma_color"									"1 .8 .4"
+
+	"OnWeaponActivate"                              "OnWeaponActivate_R101"
+    "OnWeaponDeactivate"                            "OnWeaponDeactivate_R101"
+    "OnWeaponPrimaryAttack"                         "OnWeaponPrimaryAttack_R101"
+
+	"looping_sounds"								"1"
+
+	"burst_or_looping_fire_sound_start_1p"			"Weapon_R101_FirstShot_1P"
+	"burst_or_looping_fire_sound_middle_1p"			"Weapon_R101_Loop_1P"
+	"burst_or_looping_fire_sound_end_1p"			"Weapon_R101_LoopEnd_1P"
+
+	"burst_or_looping_fire_sound_start_3p"			""
+	"burst_or_looping_fire_sound_middle_3p"			"Weapon_R101_Loop_3P"
+	"burst_or_looping_fire_sound_end_3p"			"Weapon_R101_LoopEnd_3P"
+
+	"burst_or_looping_fire_sound_start_npc"			""
+	"burst_or_looping_fire_sound_middle_npc"		"weapon_r101_loop_3p_npc_a"
+	"burst_or_looping_fire_sound_end_npc"			""
+
+	"low_ammo_sound_name_1"							"R101_LowAmmo_Shot1"
+
+	"fire_sound_1_player_1p"						"Weapon_bulletCasings.Bounce"
+	"fire_sound_1_player_3p"						"Weapon_bulletCasings.Bounce"
+	"fire_sound_2_player_1p"						"Weapon_r101_SecondShot_1P"
+	"fire_sound_2_player_3p"						""
+	"fire_sound_2_npc"								"Weapon_r101_SecondShot_NPC"
+	"sound_dryfire"									"assault_rifle_dryfire"
+	"sound_zoom_in"									"Weapon_r101_ADS_In"
+	"sound_zoom_out"								"Weapon_r101_ADS_Out"
+
+    "ammo_clip_size"   								"18"
+    "ammo_default_total"							"250"
+    "ammo_stockpile_max"							"250"
+    "ammo_no_remove_from_stockpile"					"1"
+    "ammo_min_to_fire"								"1"
+
+	// Damage - When Used by Players
+    "damage_near_value"   							"14"
+    "damage_far_value"								"14"
+    "damage_very_far_value"							"14"
+    "damage_near_value_titanarmor"					"14"
+    "damage_far_value_titanarmor" 					"14"
+    "damage_very_far_value_titanarmor" 				"14"
+	"damage_rodeo" 									"100"
+
+	"damage_leg_scale"                              "0.75"
+
+	// Behavior
+	"deployfirst_time"								"1.1"
+
+    // NPC
+	"proficiency_poor_additional_rest"				"0.2"
+	"proficiency_average_additional_rest"			"0.2"
+	"proficiency_good_additional_rest"				"0.2"
+    "proficiency_poor_spreadscale"					"5.0"
+
+    "proficiency_average_spreadscale" 				"2.0"
+    "proficiency_good_spreadscale"					"3.0"
+    "proficiency_very_good_spreadscale"   			"2.5"
+    "proficiency_perfect_spreadscale"   			"1.0"
+
+    "npc_damage_near_value"   						"10"
+    "npc_damage_far_value"							"8"
+    "npc_damage_near_value_titanarmor"				"0"
+    "npc_damage_far_value_titanarmor" 				"0"
+
+    "npc_min_engage_range"							"0"
+
+    "npc_max_range"   								"2500"
+    "npc_max_engage_range"							"2000"
+    "npc_min_engage_range_heavy_armor"				"500"
+    "npc_max_engage_range_heavy_armor"				"2000"
+
+	"npc_min_burst"   								"2"
+	"npc_max_burst"   								"4"
+	"npc_rest_time_between_bursts_min"				"0.5"
+	"npc_rest_time_between_bursts_max"				"0.8"
+
+	// Behavior
+	"fire_rate"   									"13.5"
+
+    "viewmodel_offset_hip"                          "0 1.1 0.4"
+	"viewmodel_offset_ads"							"0 0.38 0"
+
+	"dof_zoom_nearDepthStart"						"-0.5"
+	"dof_zoom_nearDepthEnd"							"5.05"
+	"dof_nearDepthStart"							"0.0"
+	"dof_nearDepthEnd"							    "0.0"
+
+	"reload_time" 									"2.4"
+	"reload_time_late1"								"1.8"
+	"reloadempty_time"								"3.2"
+	"reloadempty_time_late1"						"2.61"
+	"reloadempty_time_late2"						"1.6"
+	"vortex_refire_behavior"  						"bullet"
+	"allow_empty_fire"								"0"
+	"reload_enabled"  								"1"
+	"allow_empty_click"   							"1"
+	"empty_reload_only"   							"0"
+	"allow_headshots" 								"1"
+	"primary_fire_does_not_block_sprint"			"0"
+
+	// View Kick
+	"viewkick_pattern"                              "rspn101_2"
+
+    "viewkick_spring"                               "rspn101_vkp"
+    "viewkick_spring_hot"                           "rspn101_vkp_hot"
+
+    "viewkick_spring_heatpershot"                   "1.0"
+    "viewkick_spring_cooldown_holdtime"             "0.08"
+    "viewkick_spring_cooldown_fadetime"             "0.05"
+
+    "viewmodel_spring_jolt"                          "autofire_viewmodel_jolt"
+    "viewmodel_jolt_scale"                           "1.0"
+    "viewmodel_jolt_backwardPerShot"                 "-0.3"
+    "viewmodel_jolt_roll"                            "0 3.5 0.0"
+    "viewmodel_jolt_side"                            "0 0.05 0"
+
+	"viewkick_pitch_base" 							"1.0"
+	"viewkick_pitch_random"   						"1.0"
+	"viewkick_pitch_softScale"						"2.325"   //2.1
+	"viewkick_pitch_hardScale"						"0.35"
+
+	"viewkick_yaw_base"   							"1.0"
+	"viewkick_yaw_random" 							"1.0"
+	"viewkick_yaw_random_innerexclude"				"0.05"   //0
+	"viewkick_yaw_softScale"  						"0.725"  //.65
+	"viewkick_yaw_hardScale"  						"0.35"
+
+	"viewkick_roll_base"  							"0.8"
+	"viewkick_roll_randomMin" 						"-0.2"
+	"viewkick_roll_randomMax" 						"0.2"
+	"viewkick_roll_softScale" 						"0.7"
+	"viewkick_roll_hardScale" 						"0.45"
+
+	"viewkick_hipfire_weaponFraction" 				"0.05"
+	"viewkick_hipfire_weaponFraction_vmScale" 		"0.95"
+	"viewkick_ads_weaponFraction" 					"0.0"
+	"viewkick_ads_weaponFraction_vmScale" 			"1.0"
+
+	"viewkick_scale_firstshot_hipfire"			    "1.0"
+	"viewkick_scale_min_hipfire"  					"1.0"
+	"viewkick_scale_max_hipfire"  					"1.0"
+	"viewkick_scale_firstshot_ads"					"1.0"
+	"viewkick_scale_min_ads"  						"1.0"
+	"viewkick_scale_max_ads"  						"1.0"
+	"viewkick_scale_valuePerShot" 					"1"
+	"viewkick_scale_pitch_valueLerpStart"   		"0"
+	"viewkick_scale_pitch_valueLerpEnd" 			"6"
+	"viewkick_scale_yaw_valueLerpStart"   			"0"
+	"viewkick_scale_yaw_valueLerpEnd" 				"6"
+	"viewkick_scale_valueDecayDelay"  				"0.09"
+    "viewkick_scale_valueDecayRate"   				"50"
+
+	"viewkick_perm_pitch_base" 						"0.0"
+	"viewkick_perm_pitch_random"   					"0.0"
+	"viewkick_perm_yaw_base"   						"0.0"
+	"viewkick_perm_yaw_random" 						"0.0"
+	"viewkick_perm_yaw_random_innerexclude"			"0.0"
+
+	"viewmodel_shake_forward"						"0.2"
+
+	//setting to "0" so it's tunable in Bakery
+	"sprintcycle_time"								"0"
+
+	// Bodygroups:
+	"clip_bodygroup"						"r101_magazine"
+	"clip_bodygroup_index_shown"			"0"
+	"clip_bodygroup_index_hidden"			"1"
+	"clip_bodygroup_show_for_milestone_0"	"1"
+	"clip_bodygroup_show_for_milestone_1"	"0"
+	"clip_bodygroup_show_for_milestone_2"	"1"
+	"clip_bodygroup_show_for_milestone_3"	"1"
+
+	dof_zoom_focusArea_horizontal					0.061
+	dof_zoom_focusArea_top							0.064
+	dof_zoom_focusArea_bottom						-0.016
+
+	Mods
+	{
+	    gold
+	    {
+	    }
+
+		survival_finite_ammo
+        {
+            "ammo_default_total"							"0"
+            "ammo_stockpile_max"							"44"
+            "ammo_no_remove_from_stockpile"					"0"
+
+            "low_ammo_fraction" 							"0.3"
+
+	   		"uses_ammo_pool"								"1"
+        }
+
+        // single shot
+		altfire
+		{
+			"mod_activity_modifier"							"fire_select"
+
+			"is_semi_auto"									"1"
+
+			"fire_sound_1_player_1p"						"Weapon_bulletCasings.Bounce"
+			"fire_sound_1_player_3p"						"Weapon_bulletCasings.Bounce"
+			"fire_sound_2_player_1p"						"Weapon_r101_SingleShot_1P"
+			"fire_sound_2_player_3p"						"Weapon_r101_SingleShot_3P"
+			"fire_sound_2_npc"								"Weapon_r101_SingleShot_3P"
+
+			"burst_or_looping_fire_sound_start_1p"			""
+			"burst_or_looping_fire_sound_middle_1p"			""
+			"burst_or_looping_fire_sound_end_1p"			""
+
+			"burst_or_looping_fire_sound_start_3p"			""
+			"burst_or_looping_fire_sound_middle_3p"			""
+			"burst_or_looping_fire_sound_end_3p"			""
+
+			"burst_or_looping_fire_sound_start_npc"			""
+			"burst_or_looping_fire_sound_middle_npc"		""
+			"burst_or_looping_fire_sound_end_npc"			""
+
+			"looping_sounds"								"0"
+
+			"low_ammo_sound_name_1"                         "R101_LowAmmo_Shot1"
+			"low_ammo_sound_name_2"                         "R101_LowAmmo_Shot2"
+			"low_ammo_sound_name_3"                         "R101_LowAmmo_Shot3"
+			"low_ammo_sound_name_4"                         "R101_LowAmmo_Shot4"
+			"low_ammo_sound_name_5"                         "R101_LowAmmo_Shot5"
+			"low_ammo_sound_name_6"                         "R101_LowAmmo_Shot6"
+		}
+
+                      
+        hopup_highcal_rounds
+        {
+        	// This mod is only used to indicate that the hop-up is active
+        	// When player changes fire modes, we activate "altfire_empowered"
+        }
+
+        // single shot empowered
+        altfire_highcal
+        {
+            "mod_activity_modifier"							"fire_select"
+
+            "is_semi_auto"									"1"
+
+			"projectile_trail_effect_0"                     "P_tracer_proj_sniper_piercer"
+
+            "fire_sound_1_player_1p"						"Weapon_bulletCasings.Bounce"
+            "fire_sound_1_player_3p"						"Weapon_bulletCasings.Bounce"
+            "fire_sound_2_player_1p"						"Weapon_r101_SingleShot_1P"
+            "fire_sound_2_player_3p"						"Weapon_r101_SingleShot_3P"
+            "fire_sound_2_npc"								"Weapon_r101_SingleShot_3P"
+
+            "burst_or_looping_fire_sound_start_1p"			""
+            "burst_or_looping_fire_sound_middle_1p"			""
+            "burst_or_looping_fire_sound_end_1p"			""
+
+            "burst_or_looping_fire_sound_start_3p"			""
+            "burst_or_looping_fire_sound_middle_3p"			""
+            "burst_or_looping_fire_sound_end_3p"			""
+
+            "burst_or_looping_fire_sound_start_npc"			""
+            "burst_or_looping_fire_sound_middle_npc"		""
+            "burst_or_looping_fire_sound_end_npc"			""
+
+            "looping_sounds"								"0"
+
+            "low_ammo_sound_name_1"                         "R101_LowAmmo_Shot1"
+            "low_ammo_sound_name_2"                         "R101_LowAmmo_Shot2"
+            "low_ammo_sound_name_3"                         "R101_LowAmmo_Shot3"
+            "low_ammo_sound_name_4"                         "R101_LowAmmo_Shot4"
+            "low_ammo_sound_name_5"                         "R101_LowAmmo_Shot5"
+            "low_ammo_sound_name_6"                         "R101_LowAmmo_Shot6"
+
+            // behavior
+	        "fire_rate"   					                "3.5"   //"13.5"
+
+            "damage_near_value"   							"35"
+            "damage_far_value"								"35"
+            "damage_very_far_value"							"35"
+            "damage_near_value_titanarmor"					"35"
+            "damage_far_value_titanarmor" 					"35"
+            "damage_very_far_value_titanarmor" 				"35"
+
+            "damage_leg_scale"                              "0.9"
+
+            "ammo_per_shot" 				                "2"
+            "ammo_min_to_fire"				                "1"
+
+            // viewkick
+            "viewkick_pattern"                              "rspn101_highcal"
+
+            "viewkick_spring" 						        "rspn101_highcal_vkp"
+            "viewkick_spring_hot"                           "rspn101_highcal_vkp_hot"
+            "viewkick_spring_cooldown_holdtime"             "0.26"
+            "viewkick_spring_cooldown_fadetime"             "0.18"
+
+            "viewkick_scale_valueDecayDelay"                "0.48"
+            "viewkick_scale_valueDecayRate"                 "25"
+
+            "viewkick_pitch_base" 							"1.0"
+            "viewkick_pitch_random"   						"1.0"
+            "viewkick_pitch_softScale"						"2.9"
+            "viewkick_pitch_hardScale"						"0.4"
+
+            "viewkick_yaw_base"   							"1.0"
+            "viewkick_yaw_random" 							"1.0"
+            "viewkick_yaw_random_innerexclude"				"0.05"
+            "viewkick_yaw_softScale"  						"1.4"
+            "viewkick_yaw_hardScale"  						"0.2"
+
+            "viewkick_roll_base"  	                        "1.85"
+            "viewkick_roll_randomMin"                       "-0.2"
+            "viewkick_roll_randomMax"                       "0.2"
+            "viewkick_roll_softScale"                       "1.1"
+            "viewkick_roll_hardScale"                       "0.25"
+
+            "viewkick_hipfire_weaponFraction" 				"0.125"
+
+            "viewmodel_jolt_scale"                          "1.9"           //1.0
+            "viewmodel_jolt_backwardPerShot"                "-0.65"         //-0.3
+            "viewmodel_jolt_roll"                           "0 3.9 0.0"     //0 3.5 0
+            "viewmodel_jolt_side"                           "0 0.065 0"     //0 0.05 0
+
+            // spread
+            "spread_stand_hip"								"6.5"   //2.5
+            "spread_stand_hip_run"							"8.5"   //5.5
+            "spread_stand_hip_sprint"                       "9.5"   //7.0
+            "spread_crouch_hip"   							"5.0"   //2.0
+            "spread_air_hip"  								"9.5"   //7.0
+
+            "spread_moving_increase_rate" 					"20"    //3
+            "spread_moving_decay_rate" 						"25"    //10.5
+
+            "spread_kick_on_fire_stand_hip"   				"0.65"  //0.2
+            "spread_kick_on_fire_crouch_hip"  				"0.65"  //0.2
+            "spread_kick_on_fire_air_hip" 					"0.65"  //0.2
+
+            "spread_max_kick_stand_hip"   					"9.0"   //2.0
+            "spread_max_kick_crouch_hip"  					"6.0"   //1.5
+            "spread_max_kick_air_hip" 						"9.0"   //3.0
+
+            "spread_decay_delay"  							"0.275" //0.25
+            "spread_decay_rate"   							"12"    //10
+        }
+// end HAS_HIGHCAL_ROUNDS
+      
+
+		barrel_stabilizer_l4_flash_hider
+		{
+			"fx_muzzle_flash_view"		"wpn_muzzleflash_assault_sup_FP"
+			"fx_muzzle_flash_world"		"wpn_muzzleflash_assault_sup"
+		}
+
+		bullets_mag_l1
+		{
+			"ammo_clip_size" 					"20"
+		}
+		bullets_mag_l2
+		{
+			"ammo_clip_size" 					"25"
+		}
+		bullets_mag_l3
+		{
+			"ammo_clip_size" 					"28"
+		}
+
+        hopup_stock
+		{
+			"zoom_time_in"						"*0"
+			"zoom_time_out"   					"*0"
+
+			"deploy_time" 						"*0.01"
+			"holster_time"						"*0.01"
+			"raise_time" 						"*0.01"
+			"lower_time"						"*0.01"
+
+			"viewdrift_ads_stand_scale_pitch" 	"*0"
+	        "viewdrift_ads_stand_scale_yaw"   	"*0"
+	        "viewdrift_ads_crouch_scale_pitch"  "*0"
+	        "viewdrift_ads_crouch_scale_yaw"	"*0"
+	        "viewdrift_ads_air_scale_pitch"   	"*0"
+	        "viewdrift_ads_air_scale_yaw" 		"*0"
+		}
+
+		hopup_mag
+		{
+			"ammo_no_remove_from_clip"	"1"
+		}
+
+		hopup_sight
+		{
+			"threat_scope_enabled"			    "1"
+		}
+		hopup_barrel
+		{
+			"bodygroup26_set"                   "1"
+
+		    "fx_muzzle_flash_attach"	        "muzzle_flash_suppressor_small"
+
+			"fx_muzzle_flash_view"		        "wpn_muzzleflash_pistol_sup_FP"
+			"fx_muzzle_flash_world"		        "wpn_muzzleflash_pistol_sup"
+
+			"viewkick_pitch_base" 				"*0"
+			"viewkick_pitch_random"   			"*0"
+			"viewkick_yaw_base" 				"*0"
+			"viewkick_yaw_random"   			"*0"
+		}
+      
+	  	hopup_infinity
+		{
+			"fire_rate"			"18"
+			// Hipfire Spread
+    		"spread_stand_hip"								"0.0"
+   			"spread_stand_hip_run"							"0.0"
+	    	"spread_stand_hip_sprint"                       "0.0"
+	    	"spread_crouch_hip"   							"0.0"
+ 	   		"spread_air_hip"  								"0.0"
+
+ 	   		"spread_moving_increase_rate" 					"10"
+ 	   		"spread_moving_decay_rate" 						"10"
+
+ 	   		"spread_kick_on_fire_stand_hip"   				"0"
+ 	   		"spread_kick_on_fire_crouch_hip"  				"0"
+ 	   		"spread_kick_on_fire_air_hip" 					"0"
+
+	    	"spread_decay_delay"  							"0.25"
+	    	"spread_decay_rate"   							"10"
+
+	    	"spread_stand_ads"								"0"
+    		"spread_crouch_ads"   							"0"
+    		"spread_air_ads"  								"0.0"
+
+    		"spread_kick_on_fire_stand_ads"   				"0"
+    		"spread_kick_on_fire_crouch_ads"  				"0"
+    		"spread_kick_on_fire_air_ads" 					"0"
+
+    		"spread_max_kick_stand_ads"   					"0"
+   			"spread_max_kick_crouch_ads"  					"0"
+    		"spread_max_kick_air_ads" 						"0"
+		}
+	}
+
+
+	"ui1_enable"		"1"
+	"ui1_draw_cloaked"	"1"
+	UiData1
+	{
+		"ui"							"ui/r301_reticle"
+		"mesh"							"models/weapons/attachments/r301_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+			ammo						weapon_ammo
+			clipSize					weapon_clipSize
+		}
+	}
+
+	"ui2_enable"		"1"
+	UiData2
+	{
+		"ui"							"ui/r101_ammo_counter"
+		"mesh"							"models/weapons/attachments/r101_rui_lower"
+		Args
+		{
+			vis							player_zoomfrac
+			ammo						weapon_ammo
+			clipSize					weapon_clipSize
+		}
+	}
+
+
+	active_crosshair_count				"1"
+	rui_crosshair_index					"0"
+
+	RUI_CrosshairData
+	{
+		DefaultArgs
+		{
+			adjustedSpread				weapon_spread
+			adsFrac 					player_zoomFrac
+			isSprinting					player_is_sprinting
+			isReloading					weapon_is_reloading
+			teamColor					crosshair_team_color
+			isAmped						weapon_is_amped
+			crosshairMovementX          crosshair_movement_x
+			crosshairMovementY          crosshair_movement_y
+		}
+
+		Crosshair_1
+		{
+			"ui"						"ui/crosshair_tri"
+			"base_spread"				"0.0"
+			Args
+			{
+				//isFiring				weapon_is_firing
+			}
+		}
+	}
+}


### PR DESCRIPTION
Oh wow, I guess this DOES fit in here.

**Custom Weapons And Attachments 1.1**
Now you can make your own attachments (custom generic items coming soon™) using a modular, easy to modify system.
**TO-DO:** make this use playlists.

Comes with the **Infinity Rifle**:
A modified R-301 that can take special red attachments found around the map -  the **Infinity Barrel**, **Infinity Mag**, **Infinity Sight**, **Infinity Stock**, and **Infinity Hop-Up**, all of which make the weapon overpowered in different ways.

Comes with a **Cool Hop-Up** and @Edorion#1761's **EPG** too.

Custom Weapons and Attachments can now appear on the ground as normal loot - and chances can be customized.