### PR TITLE
Changed int to float in suicide spectre function

### DIFF
--- a/vscripts/ai/_ai_suicide_spectres.gnut
+++ b/vscripts/ai/_ai_suicide_spectres.gnut
@@ -261,8 +261,8 @@ void function SuicideSpectre_WaittillNearEnemyOrExploding( entity spectre )
 
 	bool pursuitSoundPlaying = false
 
-	int minScale = expect int( spectre.Dev_GetAISettingByKeyField( "minSpeedScale" ) )
-	int maxScale = expect int( spectre.Dev_GetAISettingByKeyField( "maxSpeedScale" ) )
+	float minScale = expect float( spectre.Dev_GetAISettingByKeyField( "minSpeedScale" ) )
+	float maxScale = expect float( spectre.Dev_GetAISettingByKeyField( "maxSpeedScale" ) )
 
 	while ( true )
 	{


### PR DESCRIPTION
Will crash here without changes when spawning a tick.

`ent_create npc_frag_drone` to spawn a tick