### PR TITLE
Fixed so that downed sound can be heard by surrounding players

### DIFF
--- a/vscripts/mp/_bleedout.gnut
+++ b/vscripts/mp/_bleedout.gnut
@@ -112,7 +112,7 @@ void function Bleedout_StartPlayerBleedout( entity player, entity attacker )
 	player.SetPlayerNetInt( "bleedoutType", EquipmentSlot_GetEquipmentTier( player, "incapshield" ) )
 	player.SetHealth( 100 )
 
-	EmitSoundOnEntity( player, "flesh_bulletimpact_downedshot_3p_vs_3p" )
+	EmitSoundOnEntityExceptToPlayer( player, attacker, "flesh_bulletimpact_downedshot_3p_vs_3p" )
 
 	PlayBattleChatterLineToSpeakerAndTeam( player, "bc_imDown" )
 

--- a/vscripts/mp/_bleedout.gnut
+++ b/vscripts/mp/_bleedout.gnut
@@ -112,7 +112,10 @@ void function Bleedout_StartPlayerBleedout( entity player, entity attacker )
 	player.SetPlayerNetInt( "bleedoutType", EquipmentSlot_GetEquipmentTier( player, "incapshield" ) )
 	player.SetHealth( 100 )
 
-	EmitSoundOnEntityExceptToPlayer( player, attacker, "flesh_bulletimpact_downedshot_3p_vs_3p" )
+	if( attacker.IsPlayer() && attacker != null )
+		EmitSoundOnEntityExceptToPlayer( player, attacker, "flesh_bulletimpact_downedshot_3p_vs_3p" )
+	else
+		EmitSoundOnEntity( player, "flesh_bulletimpact_downedshot_3p_vs_3p" )
 
 	PlayBattleChatterLineToSpeakerAndTeam( player, "bc_imDown" )
 

--- a/vscripts/mp/_bleedout.gnut
+++ b/vscripts/mp/_bleedout.gnut
@@ -101,16 +101,18 @@ void function Bleedout_StartPlayerBleedout( entity player, entity attacker )
 	//if the player is already bleeding don't restart bleeding logic.
 	if ( file.isBleeding[ player ] )
 		return
-	
+
 	player.Signal( "BleedOut_StopBleeding" )
 	player.Signal( "BleedOut_OnStartDying" )
 
 	file.lastAttacker[ player ] = attacker
-	
+
 	thread Bleedout_DeathProtection( player )
-	
+
 	player.SetPlayerNetInt( "bleedoutType", EquipmentSlot_GetEquipmentTier( player, "incapshield" ) )
 	player.SetHealth( 100 )
+
+	EmitSoundOnEntity( player, "flesh_bulletimpact_downedshot_3p_vs_3p" )
 
 	PlayBattleChatterLineToSpeakerAndTeam( player, "bc_imDown" )
 
@@ -154,7 +156,7 @@ void function PlayerDying( entity player )
 	// 	ids.append( StatusEffect_AddEndless( player, eStatusEffect.bleedoutDOF, 1.0 ) )
 
 	file.isBleeding[ player ] = true
-	
+
 	player.SetUseDoomedAnims(true)
 	player.ForceCrouch()
 	player.SetOneHandedWeaponUsageOn()
@@ -334,7 +336,7 @@ void function EnablePlayerSelfRes( entity player )
 void function PlayDocAnims(entity droneMedic, entity medicWall)
 {
 	droneMedic.EndSignal( "OnDestroy" )
-	
+
 	int fxID_VENT   = droneMedic.LookupAttachment( "VENT_BOT" )
 	int fxID_EYE    = droneMedic.LookupAttachment( "EYEGLOW" )
 	int fxID_RF     = droneMedic.LookupAttachment( "VENT_RF" )
@@ -345,12 +347,12 @@ void function PlayDocAnims(entity droneMedic, entity medicWall)
 	//drone medic beam fx, still not 100% accurate
 	entity owner = droneMedic.GetOwner()
 	entity beamfx = StartParticleEffectOnEntity_ReturnEntity( droneMedic, GetParticleSystemIndex( $"P_drone_medic_shield_beam"), FX_PATTACH_POINT_FOLLOW, fxID_EYE)
-	
+
 	beamfx.DisableHibernation()
-	
+
 	// EffectSetControlPointVector( beamfx, 0, droneMedic.GetOrigin()) //beam start point
 	EffectSetControlPointVector( beamfx, 1, owner.GetOrigin() + <0,0,45> + owner.GetForwardVector()*70 + owner.GetRightVector()*30) //beam endpoint
-	
+
 	StartParticleEffectOnEntity_ReturnEntity( droneMedic, GetParticleSystemIndex( FX_DRONE_MEDIC_EYE ), FX_PATTACH_POINT_FOLLOW, fxID_EYE )
 	StartParticleEffectOnEntity_ReturnEntity( droneMedic, GetParticleSystemIndex( FX_DRONE_MEDIC_JET_CTR ), FX_PATTACH_POINT_FOLLOW, fxID_VENT )
 	StartParticleEffectOnEntity_ReturnEntity( droneMedic, GetParticleSystemIndex( FX_DRONE_MEDIC_JET_CTR ), FX_PATTACH_POINT_FOLLOW, fxID_VENT )
@@ -358,7 +360,7 @@ void function PlayDocAnims(entity droneMedic, entity medicWall)
 	StartParticleEffectOnEntity_ReturnEntity( droneMedic, GetParticleSystemIndex( FX_DRONE_MEDIC_JET_LOOP ), FX_PATTACH_POINT_FOLLOW, fxID_LF )
 	StartParticleEffectOnEntity_ReturnEntity( droneMedic, GetParticleSystemIndex( FX_DRONE_MEDIC_JET_LOOP ), FX_PATTACH_POINT_FOLLOW, fxID_RR )
 	StartParticleEffectOnEntity_ReturnEntity( droneMedic, GetParticleSystemIndex( FX_DRONE_MEDIC_JET_LOOP ), FX_PATTACH_POINT_FOLLOW, fxID_LR )
-	
+
 	// Anim
 	float animTime = droneMedic.GetSequenceDuration( "lifeline_drone_revive" )
 	PlayAnim( droneMedic, "lifeline_drone_revive" )
@@ -367,7 +369,7 @@ void function PlayDocAnims(entity droneMedic, entity medicWall)
 
 	if( IsValid( beamfx ) )
 		beamfx.Destroy()
-	
+
 	wait 0.2
 }
 
@@ -397,13 +399,13 @@ void function PlayerAttemptRes( entity playerHealer, entity playerToRes )
 	string characterRef = ItemFlavor_GetHumanReadableRef( character )
 	entity medicWall
 	entity docdrone
-	
+
 	switch( characterRef )
 	{
 		case "character_lifeline":
 			healerAnimation = "mp_pt_light_revive_quick_healthy"
 			toResAnimation = "Pilot_doomed_revive_quick_injured"
-			
+
 			vector angles = AnglesCompose( playerHealer.GetAngles(), <0,180,0> )
 			medicWall = CreatePropDynamic( $"mdl/fx/medic_shield_wall.rmdl", playerHealer.GetOrigin() + <0,0,0> + playerHealer.GetForwardVector()*20 + playerHealer.GetRightVector()*30 , angles, SOLID_VPHYSICS )
 			medicWall.kv.contents = (CONTENTS_WINDOW)
@@ -416,17 +418,17 @@ void function PlayerAttemptRes( entity playerHealer, entity playerToRes )
 			medicWall.SetDamageNotifications( true )
 			//medicWall.SetMaxHealth( 350 )
 			//medicWall.SetHealth( 350 )
-			
+
 			EmitSoundOnEntity(medicWall, "Lifeline_ReviveShield_Sustain_3P")
-			
+
 			docdrone = CreatePropDynamic( $"mdl/props/lifeline_drone/lifeline_drone.rmdl", medicWall.GetOrigin() + <0,0,0>, angles, SOLID_VPHYSICS )
 			docdrone.SetOwner(playerHealer)
-			thread PlayDocAnims(docdrone, medicWall) 
-				
-			SetVisibleEntitiesInConeQueriableEnabled( medicWall, true )			
+			thread PlayDocAnims(docdrone, medicWall)
+
+			SetVisibleEntitiesInConeQueriableEnabled( medicWall, true )
 			SetTeam( medicWall, TEAM_BOTH )
 			medicWall.SetPassThroughThickness( 0 )
-			medicWall.SetPassThroughDirection( -0.30 )	
+			medicWall.SetPassThroughDirection( -0.30 )
 			break
 		case "character_wattson":
 			healerAnimation = "Pilot_doomed_revive_shock_healthy"
@@ -477,7 +479,7 @@ void function PlayerAttemptRes( entity playerHealer, entity playerToRes )
 				file.IsGivingFirstAidTo[ playerHealer ] = null
 				DestroyPlayAnimationEntityBlocker( playerHealer )
 				playerHealer.Anim_Stop()
-				playerHealer.ClearParent()				
+				playerHealer.ClearParent()
 				ClearPlayerAnimViewEntity( playerHealer )
 				DeployAndEnableWeapons( playerHealer )
 				playerHealer.MovementEnable()
@@ -509,7 +511,7 @@ void function PlayerAttemptRes( entity playerHealer, entity playerToRes )
 			}
 		}
 	)
-	
+
 	CreatePlayAnimationEntityBlocker( playerHealer, false )
 	CreatePlayAnimationEntityBlocker( playerToRes, false )
 
@@ -523,7 +525,7 @@ void function PlayerAttemptRes( entity playerHealer, entity playerToRes )
 	reviverSequence.thirdPersonCameraVisibilityChecks = true
 	reviverSequence.playerPushable = true
 	reviverSequence.snapPlayerFeetToEyes = false
-	
+
 	FirstPersonSequenceStruct toResSequence
 	toResSequence.blendTime = 0.25
 	toResSequence.attachment = "ref"
@@ -539,9 +541,9 @@ void function PlayerAttemptRes( entity playerHealer, entity playerToRes )
 		reviverSequence.noParent = true
 		reviverSequence.useAnimatedRefAttachment = false
 	}
-	
+
 	thread FirstPersonSequence( reviverSequence, playerHealer )
-	
+
 	if ( !selfRes )
 	{
 		PlayBattleChatterLineToSpeakerAndTeam( playerHealer, "bc_revivingPlayer" )


### PR DESCRIPTION
When a player is knocked down, "flesh_bulletimpact_downshot_3p_vs_3p" is played.
This not only lets the surrounding players know that a player has been knocked down, but when a player is knocked down by lava or bots, the player will hear himself being knocked down. (The original script does not sound anything.)