### PR TITLE
Fixed an issue where putting away a grenade while holding it would cause the grenade to be thrown

### DIFF
--- a/vscripts/weapons/_grenade.nut
+++ b/vscripts/weapons/_grenade.nut
@@ -197,8 +197,7 @@ var function Grenade_OnWeaponTossReleaseAnimEvent( entity weapon, WeaponPrimaryA
 
 var function Grenade_OnWeaponTossCancelDrop( entity weapon, WeaponPrimaryAttackParams attackParams )
 {
-	var result = Grenade_OnWeaponToss( weapon, attackParams, 0.2 )
-	return result
+	return 0
 }
 
 // Can return entity or nothing


### PR DESCRIPTION
If you put away the grenade while holding it, you can throw it without reducing the grenade. 
(The grenade does not disappear from your inventory.)

The grenade will no longer be able to be held, but if you drop it or switch to another grenade,
you will be able to hold it again and throw it.

If you exploit this bug, you can throw grenades indefinitely.
Here is a video of what has changed: https://clipchamp.com/watch/5BZNprsYN3J