### PR TITLE
Add "Knocked down an enemy" notification

### DIFF
--- a/vscripts/gamemodes/_gamemode_survival.nut
+++ b/vscripts/gamemodes/_gamemode_survival.nut
@@ -379,20 +379,25 @@ void function OnPlayerDamaged( entity victim, var damageInfo )
 	if ( !( DamageInfo_GetCustomDamageType( damageInfo ) & DF_BYPASS_SHIELD ) )
 		currentHealth += victim.GetShieldHealth()
 
-	if ( currentHealth - damage <= 0 && PlayerRevivingEnabled() && !IsInstantDeath(damageInfo) )
-	{
-		entity attacker = DamageInfo_GetAttacker( damageInfo )
+	entity attacker = DamageInfo_GetAttacker( damageInfo )
 
+	vector damagePosition = DamageInfo_GetDamagePosition( damageInfo )
+	int damageType = DamageInfo_GetCustomDamageType( damageInfo )
+
+	StoreDamageHistoryAndUpdate( victim, Time() + 30, damage, damagePosition, damageType, sourceId, attacker )
+
+	if ( currentHealth - damage <= 0 && PlayerRevivingEnabled() && !IsInstantDeath( damageInfo ) )
+	{
 		// Supposed to be bleeding
-		Bleedout_StartPlayerBleedout( victim, DamageInfo_GetAttacker( damageInfo ) )
+		Bleedout_StartPlayerBleedout( victim, attacker )
 
 		// Add the cool splashy blood and big red crosshair hitmarker
 		DamageInfo_AddCustomDamageType( damageInfo, DF_KILLSHOT )
 
 		// Notify the player of the damage (even though it's *technically* canceled and we're hijacking the damage in order to not make an alive 100hp player instantly dead with a well placed kraber shot)
-		if (attacker.IsPlayer() && !IsWorldSpawn(attacker))
+		if (attacker.IsPlayer() && !IsWorldSpawn( attacker ))
         {
-            attacker.NotifyDidDamage( victim, DamageInfo_GetHitBox( damageInfo ), DamageInfo_GetDamagePosition( damageInfo ), DamageInfo_GetCustomDamageType( damageInfo ), DamageInfo_GetDamage( damageInfo ), DamageInfo_GetDamageFlags( damageInfo ), DamageInfo_GetHitGroup( damageInfo ), DamageInfo_GetWeapon( damageInfo ), DamageInfo_GetDistFromAttackOrigin( damageInfo ) )
+            attacker.NotifyDidDamage( victim, DamageInfo_GetHitBox( damageInfo ), damagePosition, damageType, damage, DamageInfo_GetDamageFlags( damageInfo ), DamageInfo_GetHitGroup( damageInfo ), DamageInfo_GetWeapon( damageInfo ), DamageInfo_GetDistFromAttackOrigin( damageInfo ) )
         }
 		// Cancel the damage
 		// Setting damage to 0 cancels all knockback, setting it to 1 doesn't
@@ -402,11 +407,15 @@ void function OnPlayerDamaged( entity victim, var damageInfo )
 		// Delete any shield health remaining
 		victim.SetShieldHealth( 0 )
 
-		// Run client callback
-		int scriptDamageType = DamageInfo_GetCustomDamageType( damageInfo )
+		if( GetGameState() >= eGameState.Playing && attacker.IsPlayer() )
+		{
+			ScoreEvent event = GetScoreEvent( "Sur_DownedPilot" )
+
+			Remote_CallFunction_NonReplay( attacker, "ServerCallback_ScoreEvent", event.eventId, event.pointValue, event.displayType, victim.GetEncodedEHandle(), GetTotalDamageTakenByPlayer( victim, attacker ), 0 )
+		}
 
 		foreach ( cbPlayer in GetPlayerArray() )
-			Remote_CallFunction_Replay( cbPlayer, "ServerCallback_OnEnemyDowned", attacker, victim, scriptDamageType, sourceId )
+			Remote_CallFunction_Replay( cbPlayer, "ServerCallback_OnEnemyDowned", attacker, victim, damageType, sourceId )
 	}
 }
 

--- a/vscripts/gamemodes/_gamemode_survival.nut
+++ b/vscripts/gamemodes/_gamemode_survival.nut
@@ -407,7 +407,7 @@ void function OnPlayerDamaged( entity victim, var damageInfo )
 		// Delete any shield health remaining
 		victim.SetShieldHealth( 0 )
 
-		if( GetGameState() >= eGameState.Playing && attacker.IsPlayer() )
+		if( GetGameState() >= eGameState.Playing && attacker.IsPlayer() && attacker != victim )
 		{
 			ScoreEvent event = GetScoreEvent( "Sur_DownedPilot" )
 

--- a/vscripts/mp/_score.nut
+++ b/vscripts/mp/_score.nut
@@ -66,7 +66,10 @@ void function AddPlayerScore( entity targetPlayer, string scoreEventName, entity
 
 void function ScoreEvent_PlayerKilled( entity victim, entity attacker, var damageInfo )
 {
-	AddPlayerScore( attacker, "KillPilot", victim )
+	if( GetGameState() >= eGameState.Playing )
+		AddPlayerScore( attacker, "EliminatePilot", victim )
+	else
+		AddPlayerScore( attacker, "KillPilot", victim )
 	
 	if ( DamageInfo_GetCustomDamageType( damageInfo ) & DF_HEADSHOT )
 		AddPlayerScore( attacker, "Headshot", victim )


### PR DESCRIPTION
It displays a "knocked down the enemy" notification.

Like this:
![image](https://user-images.githubusercontent.com/90076182/187679417-c6a41291-1b13-4e2d-b9a9-2a40f9c80c79.png)

To display the damage inflicted, I used StoreDamageHistoryAndUpdate() function.

Also, the notification when an enemy is eliminated has been changed from "KILLED" to "ELIMINATED".
![image](https://user-images.githubusercontent.com/90076182/187680978-e9891723-112c-4f99-adab-b970e277583f.png)

These changes will only take effect when eGameState is Playing or higher, not when WaitingForPlayers.

(e.g. in firing range, knockdown notifications will not be displayed,

and notifications when an enemy is killed will show "KILLED" instead of "ELIMINATED").