### PR TITLE
Announcement system updates and add deathcam

### DIFF
--- a/vscripts/conversation/_survival_commentary.gnut
+++ b/vscripts/conversation/_survival_commentary.gnut
@@ -204,8 +204,8 @@ void function AddSurvivalCommentaryEvent( int event, entity attacker = null, ent
 			thread SurvivalCommentary_KilledPlayerAnnounce( eSurvivalCommentaryBucket.FIRST_BLOOD, attacker, 1.0, "bc_firstBlood", "bc_weTookFirstBlood" )
 			break;
 	}
-	// The announcer should only be the Revenant when the playlist is Shadow Falls
-	// Host type is changed to NOC during shadow fall
+	// The announcer's voice can be changed with SurvivalCommentary_SetHost()
+	// For example, to change to a revenant announcement, execute "SurvivalCommentary_SetHost( eSurvivalHostType.NOC )"
 }
 
 int function GetRoundCommentaryBucket( int round )

--- a/vscripts/conversation/_survival_commentary.gnut
+++ b/vscripts/conversation/_survival_commentary.gnut
@@ -6,17 +6,25 @@ global function AddSurvivalCommentaryEvent
 global function SurvivalCommentary_InitThreatChatterForPlayer
 global function SurvivalCommentary_OnThreatActivationBombardment
 global function SurvivalCommentary_OnThreatActivationGrenade
+global function SurvivalCommentary_HostAnnounce
+global function SurvivalCommentary_KilledPlayerAnnounce
+
+global function SetKillLeader
+global function GetKillLeader
+global function SetChampion
+global function GetChampion
 
 struct {
 	int currentKillLeaderKillAmount = 0
 	entity currentKillLeader = null
+	entity currentChampion = null
 } file
 
 void function SurvivalCommentary_Init()
 {
 	ShSurvivalCommentary_Init()
 
-	if ( !IsFiringRangeGameMode() )
+	if ( !IsFiringRangeGameMode() && GameRules_GetGameMode() == SURVIVAL )
 		AddCallback_OnPlayerKilled( OnPlayerKilled )
 
 	FlagInit( "SurvivalCommentary_FirstBloodReached", false )
@@ -24,52 +32,58 @@ void function SurvivalCommentary_Init()
 
 int function SurvivalCommentary_GetKillLeaderEEH()
 {
-	if ( file.currentKillLeader == null || !IsValid( file.currentKillLeader ) )
+	if ( !IsValid( file.currentKillLeader ))
 		return EncodedEHandle_null
 
 	return file.currentKillLeader.GetEncodedEHandle()
 }
 
+entity function GetKillLeader()
+{
+	if ( !IsValid( file.currentKillLeader ) )
+		return null
+
+	return file.currentKillLeader
+}
+
 int function SurvivalCommentary_GetChampionTeam()
 {
-	return 0
+	return GetEntityFromEncodedEHandle( GetGlobalNetInt( "championEEH" ) ).GetTeam()
 }
 
 int function SurvivalCommentary_GetChampionEEH()
 {
-	return 0
+	return GetGlobalNetInt( "championEEH" )
 }
 
-void function SetKillLeader( entity killLeader, int numKills )
+void function SetKillLeader( entity killLeader, int numKills, bool isCustom_TDM = false )
 {
-	wait 1.0
-
 	file.currentKillLeader = killLeader
 	file.currentKillLeaderKillAmount = numKills
-
-	int killLeaderTeam = killLeader.GetTeam()
-
+	
+	if(!isCustom_TDM)
+		wait 1.0
+	
+	if(!IsValid(killLeader)) return
+	
 	foreach ( player in GetPlayerArray() )
 		Remote_CallFunction_NonReplay( player, "ServerCallback_Survival_NewKillLeader", killLeader, numKills )
+}
 
-	int maxTeams = GetCurrentPlaylistVarInt( "max_teams", MAX_TEAMS )
-	for ( int i = TEAM_MULTITEAM_FIRST; i < TEAM_MULTITEAM_FIRST + maxTeams; ++i )
-	{
-		if ( i == killLeaderTeam )
-			continue
+void function SetChampion( entity champion )
+{
+	SetGlobalNetInt( "championEEH", champion.GetEncodedEHandle() )
+	array<entity> championSquadMates = GetPlayerArrayOfTeam( champion.GetTeam() )
+	championSquadMates.fastremovebyvalue( champion )
+	if( championSquadMates.len() >= 1 )
+		SetGlobalNetInt( "championSquad1EEH", championSquadMates[0].GetEncodedEHandle() )
+	if( championSquadMates.len() >= 2 )
+		SetGlobalNetInt( "championSquad2EEH", championSquadMates[1].GetEncodedEHandle() )
+}
 
-		entity speakingPlayer = TryFindSpeakingPlayerOnTeam( i )
-		if ( speakingPlayer != null )
-			PlayBattleChatterLineToSpeakerAndTeam( speakingPlayer, "bc_killLeaderNew" )
-	}
-
-	thread PlayDialogueForPlayer( "bc_iBecomeKillLeader", killLeader, killLeader )
-
-	array<entity> teamMembers = GetPlayerArrayOfTeam( killLeaderTeam )
-	teamMembers.fastremovebyvalue( killLeader )
-
-	foreach ( teamMember in teamMembers )
-		thread PlayDialogueForPlayer( "bc_squadmateBecomesKillLeader", teamMember, teamMember )
+entity function GetChampion()
+{
+	return file.currentChampion
 }
 
 int function GetMinKillsForKillLeader()
@@ -86,7 +100,7 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 	{
 		if ( victim == file.currentKillLeader )
 		{
-			PlayBattleChatterLineToSpeakerAndTeam( attacker, "bc_weKilledKillLeader" )
+			thread SurvivalCommentary_KilledPlayerAnnounce( eSurvivalCommentaryBucket.KILL_LEADER_ELIMINATED, attacker, 1.0, "", "bc_weKilledKillLeader" )
 
 			foreach ( player in GetPlayerArray() )
 				Remote_CallFunction_NonReplay( player, "ServerCallback_Survival_HighlightedPlayerKilled", victim, attacker, eSurvivalCommentaryPlayerType.KILLLEADER )
@@ -97,15 +111,30 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 				&& attacker != file.currentKillLeader 
 				&& attackerKills >= GetMinKillsForKillLeader()
 			)
+		{
 			thread SetKillLeader( attacker, attackerKills )
+			thread SurvivalCommentary_KilledPlayerAnnounce( eSurvivalCommentaryBucket.NEW_KILL_LEADER, attacker, 1.0, "bc_killLeaderNew", "bc_squadmateBecomesKillLeader", "bc_iBecomeKillLeader", true )
+		}
 	}
+	
+	if ( GetCurrentPlaylistVarBool( "survival_commentary_champion_enabled", true ) )
+	{
+		entity champion = GetEntityFromEncodedEHandle( SurvivalCommentary_GetChampionEEH() )
+		if( victim == champion )
+		{
+			thread SurvivalCommentary_KilledPlayerAnnounce( eSurvivalCommentaryBucket.CHAMPION_ELIMINATED, attacker, 1.0, "bc_championEliminated", "bc_weKilledChampion" )
 
+			foreach ( player in GetPlayerArray() )
+				Remote_CallFunction_NonReplay( player, "ServerCallback_Survival_HighlightedPlayerKilled", victim, attacker, eSurvivalCommentaryPlayerType.CHAMPION )
+		}
+	}
+	
 	if ( GetCurrentPlaylistVarBool( "survival_commentary_first_blood_enabled", true ) )
 	{
 		if ( !Flag( "SurvivalCommentary_FirstBloodReached" ) )
 		{
 			FlagSet( "SurvivalCommentary_FirstBloodReached" )
-			PlayBattleChatterLineToSpeakerAndTeam( attacker, "bc_weTookFirstBlood" )
+			thread AddSurvivalCommentaryEvent( eSurvivalEventType.FIRST_BLOOD, attacker )
 		}
 	}
 }
@@ -146,7 +175,7 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 // 	31  NO_KILLS_FOR_TIME,
 // 	32  _count
 
-void function AddSurvivalCommentaryEvent ( int event )
+void function AddSurvivalCommentaryEvent( int event, entity attacker = null, entity victim = null )
 {
 	#if DEVELOPER
 	string enumString = GetEnumString( "eSurvivalEventType", event )
@@ -154,66 +183,158 @@ void function AddSurvivalCommentaryEvent ( int event )
 	printt( FUNC_NAME(), "eSurvivalEventType:", enumString, event )
 	#endif
 
-
-	if ( GetMapName() == "mp_rr_canyonlands_mu1_night" || GetMapName() == "mp_rr_desertlands_64k_x_64k_nx" )
-	{	
-		switch( event )
-		{
-			case eSurvivalEventType.CIRCLE_MOVING:
-			//GetAnyDialogueAliasFromName( PickCommentaryLineFromBucket( eSurvivalCommentaryBucket.CIRCLE_MOVING ) )
-				thread SurvivalCommentary_PlaySoundForAllPlayers( SurvivalCommentary_GetAlternativeSound( "diag_ap_nocNotify_circleMoving_01_01_3p", 2))
-				break
-			case eSurvivalEventType.ROUND_TIMER_STARTED:
-				thread SurvivalCommentary_PlaySoundForAllPlayers( "diag_ap_nocNotify_circleTimerStartRound" + SURVIVAL_GetCurrentRoundString() + "_01_01_3p" )
-				break
-			case eSurvivalEventType.FIRST_BLOOD:
-				thread SurvivalCommentary_PlaySoundForAllPlayers( "diag_ap_nocNotify_diedFirst_01_01_3p" )
-				break
-            case eSurvivalEventType.CARE_PACKAGE_DROPPING:
-                thread SurvivalCommentary_PlaySoundForAllPlayers( "diag_ap_nocNotify_droppingCarePack_01_01_3p")
-                break;
-		}
-	}
-
-	else
+	switch( event )
 	{
-		switch( event )
-		{
-			case eSurvivalEventType.CIRCLE_MOVING:
-				thread SurvivalCommentary_PlaySoundForAllPlayers( SurvivalCommentary_GetAlternativeSound( "diag_ap_aiNotify_circleMoving", 2))
-				break
-			case eSurvivalEventType.ROUND_TIMER_STARTED:
-				thread SurvivalCommentary_PlaySoundForAllPlayers( "diag_ap_aiNotify_circleTimerStartRound" + SURVIVAL_GetCurrentRoundString() )
-				break
-			case eSurvivalEventType.CIRCLE_MOVES_10SEC:
-				thread SurvivalCommentary_PlaySoundForAllPlayers( SurvivalCommentary_GetAlternativeSound( "diag_ap_aiNotify_circleMoves10sec", 2))
-				break
-            case eSurvivalEventType.CARE_PACKAGE_DROPPING:
-                thread SurvivalCommentary_PlaySoundForAllPlayers( "diag_ap_aiNotify_droppingCarePack_01")
-                break;
-		}
+		case eSurvivalEventType.CIRCLE_MOVING:
+			thread SurvivalCommentary_CircleMovingAnnounce( eSurvivalCommentaryBucket.CIRCLE_MOVING, 0 )
+			break
+		case eSurvivalEventType.CIRCLE_CLOSING_TO_NOTHING:
+			thread SurvivalCommentary_CircleMovingAnnounce( eSurvivalCommentaryBucket.CIRCLE_CLOSING_TO_NOTHING, 0 )
+			break
+		case eSurvivalEventType.FINAL_CIRCLE_MOVING:
+			thread SurvivalCommentary_CircleMovingAnnounce( eSurvivalCommentaryBucket.FINAL_CIRCLE_MOVING, 0 )
+			break
+		case eSurvivalEventType.ROUND_TIMER_STARTED:
+			thread SurvivalCommentary_CircleStartAnnounce( GetRoundCommentaryBucket( SURVIVAL_GetCurrentDeathFieldStage() ), 0 )
+			break
+		case eSurvivalEventType.CARE_PACKAGE_DROPPING:
+			thread SurvivalCommentary_HostAnnounce( eSurvivalCommentaryBucket.CARE_PACKAGE_DROPPING, 0, "bc_droppingCarePack" )
+			break;
+		case eSurvivalEventType.FIRST_BLOOD:
+			thread SurvivalCommentary_KilledPlayerAnnounce( eSurvivalCommentaryBucket.FIRST_BLOOD, attacker, 1.0, "bc_firstBlood", "bc_weTookFirstBlood" )
+			break;
 	}
-
-
+	// The announcer should only be the Revenant when the playlist is Shadow Falls
+	// Host type is changed to NOC during shadow fall
 }
 
-
-string function SurvivalCommentary_GetAlternativeSound( string sound, int max, int min = 0 )
+int function GetRoundCommentaryBucket( int round )
 {
-	int selection = RandomIntRange( min, max + 1 )
+	int roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND1
 
-	return sound + ( ( selection != 0 ) ? "_0" + selection : "" )
+	switch( round )
+	{
+		case 1:
+			roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND2
+			break
+		case 2:
+			roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND3
+			break
+		case 3:
+			roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND4
+			break
+		case 4:
+			roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND5
+			break
+		case 5:
+			roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND6
+			break
+		case 6:
+			roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND7
+			break
+		case 7:
+			roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND8
+			break
+		case 8:
+			roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND9
+			break
+		case 9:
+			roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND_FINAL
+			break
+	}
+
+	if( SURVIVAL_IsFinalDeathFieldStage() )
+		roundeNum = eSurvivalCommentaryBucket.BEGIN_ROUND_FINAL
+
+	return roundeNum
 }
 
-void function SurvivalCommentary_PlaySoundForAllPlayers( string sound )
+void function SurvivalCommentary_HostAnnounce( int commentaryBucket, float delay = 0, string responseName = "" )
 {
-	#if DEVELOPER
-	printt( FUNC_NAME(), "playing sound:", sound, "to all players" )
-	#endif
+	foreach( player in GetPlayerArray_Alive() )
+		thread PlayDialogueForPlayer( PickCommentaryLineFromBucket( commentaryBucket ), player, null, delay, eDialogueFlags.SURVIVAL_HOST_ALL_SPEAKERS, responseName, GetPlayerArrayOfTeam_Alive( player.GetTeam() ).getrandom() )
+}
 
-	foreach( entity player in GetPlayerArray() )
+void function SurvivalCommentary_CircleStartAnnounce( int round, float delay )
+{
+	foreach( player in GetPlayerArray_Alive() )
 	{
-		thread EmitSoundOnEntityOnlyToPlayer( player, player, sound )
+		string responseName
+		int insideNextCircleMates = 0
+		foreach( squadMates in GetPlayerArrayOfTeam_Alive( player.GetTeam() ) )
+		{
+			if( !SURVIVAL_PosInSafeZone( squadMates.GetOrigin() ) )
+				continue
+			
+			insideNextCircleMates++
+		}
+		
+		if( insideNextCircleMates != 0 && insideNextCircleMates != GetPlayerArrayOfTeam_Alive( player.GetTeam() ).len() )
+			responseName = "bc_newCircle_wholeSquadNotInCircle"
+		else if ( SURVIVAL_IsFinalDeathFieldStage() )
+			responseName = "bc_circleTimerStartFinal"
+		else if( Distance( SURVIVAL_GetSafeZoneCenter(), player.GetOrigin() ) >= FAR_FROM_CIRCLE_DISTANCE * 17500 )
+			responseName = "bc_nextCircleFar"
+		else if( insideNextCircleMates == GetPlayerArrayOfTeam_Alive( player.GetTeam() ).len() )
+			responseName = "bc_insideNextCircle"
+
+		printt( "insideNextCircleMates: " + insideNextCircleMates + " responseName: " + responseName )
+		printt( "Distance between player and circle: " + Distance( SURVIVAL_GetSafeZoneCenter(), player.GetOrigin() ) )
+		thread PlayDialogueForPlayer( PickCommentaryLineFromBucket( round ), player, null, delay, eDialogueFlags.SURVIVAL_HOST_ALL_SPEAKERS, responseName, GetPlayerArrayOfTeam_Alive( player.GetTeam() ).getrandom() )
+	}
+}
+
+void function SurvivalCommentary_CircleMovingAnnounce( int bucket, float delay )
+{
+	foreach( player in GetPlayerArray_Alive() )
+	{
+		string responseName
+		int insideNextCircleMates = 0
+		foreach( squadMates in GetPlayerArrayOfTeam_Alive( player.GetTeam() ) )
+		{
+			if( !SURVIVAL_PosInSafeZone( squadMates.GetOrigin() ) )
+				continue
+			
+			insideNextCircleMates++
+		}
+		
+		if( SURVIVAL_IsFinalDeathFieldStage() )
+			responseName = "bc_circleClosingFinal"
+		else if( !SURVIVAL_PosInSafeZone( player.GetOrigin() ) && insideNextCircleMates == 0 )
+			responseName = "bc_circleMoving_allOutside"
+
+		printt( "insideNextCircleMates: " + insideNextCircleMates + " responseName: " + responseName )
+		thread PlayDialogueForPlayer( PickCommentaryLineFromBucket( bucket ), player, null, delay, eDialogueFlags.SURVIVAL_HOST_ALL_SPEAKERS, responseName, GetPlayerArrayOfTeam_Alive( player.GetTeam() ).getrandom() )
+	}
+}
+
+void function SurvivalCommentary_KilledPlayerAnnounce( int bucket, entity killer, float delay, string responseName = "", string killerMatesResponseName = "", string killerResponseName = "", bool shouldDistinctionResponse = false )
+{
+	foreach( player in GetPlayerArray_Alive() )
+	{
+		string selectedResponseName
+		entity responsePlayer
+
+		if( killer == player && shouldDistinctionResponse )
+		{
+			selectedResponseName = killerResponseName
+			responsePlayer = player
+		}
+		else if( killer.GetTeam() == player.GetTeam() )
+		{
+			array<entity> squadMates = GetPlayerArrayOfTeam_Alive( player.GetTeam() )
+			if( shouldDistinctionResponse )
+				squadMates.fastremovebyvalue( killer )
+
+			selectedResponseName = killerMatesResponseName
+			responsePlayer = squadMates.getrandom()
+		} else
+		{
+			selectedResponseName = responseName
+			responsePlayer = GetPlayerArrayOfTeam_Alive( player.GetTeam() ).getrandom()
+		}
+
+		thread PlayDialogueForPlayer( PickCommentaryLineFromBucket( bucket ), player, null, delay, eDialogueFlags.SURVIVAL_HOST_ALL_SPEAKERS, selectedResponseName, responsePlayer )
 	}
 }
 

--- a/vscripts/gamemodes/_gamemode_survival.nut
+++ b/vscripts/gamemodes/_gamemode_survival.nut
@@ -509,6 +509,11 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 	if ( !IsValid( victim ) || !IsValid( attacker ) || !victim.IsPlayer() )
 		return
 
+	if( victim.GetObserverTarget() != null )
+		victim.SetObserverTarget( null )
+
+	victim.StartObserverMode( OBS_MODE_DEATHCAM )
+
 	if ( IsFiringRangeGameMode() )
 	{
 		thread function() : ( victim )

--- a/vscripts/gamemodes/custom_tdm/_gamemode_custom_tdm.nut
+++ b/vscripts/gamemodes/custom_tdm/_gamemode_custom_tdm.nut
@@ -356,6 +356,11 @@ void function _OnPlayerConnected(entity player)
 // purpose: internal function for handling player death
 void function _OnPlayerDied( entity victim, entity attacker, var damageInfo )
 {
+    if( victim.GetObserverTarget() != null )
+		victim.SetObserverTarget( null )
+
+	victim.StartObserverMode( OBS_MODE_DEATHCAM )
+    
     switch( GetGameState() )
     {
     case eGameState.Playing:

--- a/vscripts/sh_onboarding.gnut
+++ b/vscripts/sh_onboarding.gnut
@@ -144,6 +144,13 @@ void function Sequence_WaitingForPlayers()
 
 	wait PreGame_GetWaitingForPlayersCountdown() + (introCountdownEnabled ? 0.0 : CharSelect_GetIntroMusicStartTime())
 
+	// Set champion randomly from among all players
+	if ( GetCurrentPlaylistVarBool( "survival_commentary_champion_enabled", true ) )
+	{
+		entity champion = GetPlayerArray().getrandom()
+		SetChampion( champion )
+	}
+
 	if ( !introCountdownEnabled )
 		PlayPickLoadoutMusic( false )
 


### PR DESCRIPTION
I found a way to use PlayDialogueForPlayer to announce the same way as the original game (play the announcement from the Apex screen), so I rewrote most of _survival_commentary.gnut.
The announcements use the eSurvivalCommentaryBucket.
Added responses to legend announcements.

Added a death camera. It is the same as the original.

VIDEO:
Announcement:https://streamable.com/623mi7
Death Camera:https://streamable.com/0zkv03