### PR TITLE
Fix glitchy ragdoll on deathcam

### DIFF
--- a/vscripts/gamemodes/_gamemode_survival.nut
+++ b/vscripts/gamemodes/_gamemode_survival.nut
@@ -509,11 +509,6 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 	if ( !IsValid( victim ) || !IsValid( attacker ) || !victim.IsPlayer() )
 		return
 
-	if( victim.GetObserverTarget() != null )
-		victim.SetObserverTarget( null )
-
-	victim.StartObserverMode( OBS_MODE_DEATHCAM )
-
 	if ( IsFiringRangeGameMode() )
 	{
 		thread function() : ( victim )

--- a/vscripts/gamemodes/custom_tdm/_gamemode_custom_tdm.nut
+++ b/vscripts/gamemodes/custom_tdm/_gamemode_custom_tdm.nut
@@ -356,11 +356,6 @@ void function _OnPlayerConnected(entity player)
 // purpose: internal function for handling player death
 void function _OnPlayerDied( entity victim, entity attacker, var damageInfo )
 {
-    if( victim.GetObserverTarget() != null )
-		victim.SetObserverTarget( null )
-
-	victim.StartObserverMode( OBS_MODE_DEATHCAM )
-    
     switch( GetGameState() )
     {
     case eGameState.Playing:

--- a/vscripts/sh_onboarding.gnut
+++ b/vscripts/sh_onboarding.gnut
@@ -518,6 +518,7 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 
 	victim.FreezeControlsOnServer()
 	victim.StartObserverMode( OBS_MODE_DEATHCAM )
+	victim.SetObserverTarget( null )
 }
 
 void function OnClientConnected( entity player )

--- a/vscripts/sh_onboarding.gnut
+++ b/vscripts/sh_onboarding.gnut
@@ -513,6 +513,11 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 		attacker.SetPlayerNetInt( "kills", attacker.GetPlayerNetInt( "kills" ) + 1 )
 
 	Remote_CallFunction_NonReplay( victim, "ServerCallback_YouDied", attacker, GetHealthFrac( victim ), DamageInfo_GetDamageSourceIdentifier( damageInfo ), DamageInfo_GetDamage( damageInfo ) )
+
+	victim.SetPredictionEnabled( false )
+
+	victim.FreezeControlsOnServer()
+	victim.StartObserverMode( OBS_MODE_DEATHCAM )
 }
 
 void function OnClientConnected( entity player )


### PR DESCRIPTION
i recently added a death camera with my pull request. However, the death camera was causing the corpse to behave strangely (like the first part of the animation was repeating)
this commit fixes that.
honestly this is a very small difference, but this makes it behave the same as the original