### PR TITLE
Fix a bug where the damage inflicted in knockdown notifications was doubled

### DIFF
--- a/vscripts/gamemodes/_gamemode_survival.nut
+++ b/vscripts/gamemodes/_gamemode_survival.nut
@@ -387,8 +387,6 @@ void function OnPlayerDamaged( entity victim, var damageInfo )
 	vector damagePosition = DamageInfo_GetDamagePosition( damageInfo )
 	int damageType = DamageInfo_GetCustomDamageType( damageInfo )
 
-	StoreDamageHistoryAndUpdate( victim, Time() + 30, damage, damagePosition, damageType, sourceId, attacker )
-
 	if ( currentHealth - damage <= 0 && PlayerRevivingEnabled() && !IsInstantDeath( damageInfo ) )
 	{
 		// Supposed to be bleeding
@@ -413,7 +411,6 @@ void function OnPlayerDamaged( entity victim, var damageInfo )
 		if( GetGameState() >= eGameState.Playing && attacker.IsPlayer() && attacker != victim )
 		{
 			ScoreEvent event = GetScoreEvent( "Sur_DownedPilot" )
-
 			Remote_CallFunction_NonReplay( attacker, "ServerCallback_ScoreEvent", event.eventId, event.pointValue, event.displayType, victim.GetEncodedEHandle(), GetTotalDamageTakenByPlayer( victim, attacker ), 0 )
 		}
 


### PR DESCRIPTION
in order to display the damage of the knockdown notification, the damage was saved in the StoreDamageHistoryAndUpdate function, but in fact, the damage was already saved by executing that function on PlayerTookDamage in _codecallbacks.gnut and as a result, the damage was being saved twice as much
and the damage shown was doubled

it was my mistake, sorry

![image](https://user-images.githubusercontent.com/90076182/197390338-c195fc18-5475-4cb7-8c63-ba9a6775b748.png)
